### PR TITLE
docs: state public claims directly

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -123,6 +123,11 @@ jobs:
             exit 1
           fi
 
+          if git grep -n -iE '\bnot (only|just|merely|simply|uncommon|insignificant|impossible|bad|wrong|unreasonable|unlikely|automatically|enough)\b|\bno (small|minor|mean|little)\b' -- '*.md' ':(exclude)CHANGELOG.md' ':(exclude)plugins/**/CHANGELOG.md'; then
+            echo "litotes or negative comparison framing found"
+            exit 1
+          fi
+
   markdown:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ this repository is an opinionated, source-backed handbook for experienced coding
 - do not use generated activity, commit frequency, or vendor benchmarks as evidence of quality.
 - keep the voice direct, lowercase, and professional. avoid hype, fan language, and unsupported authority claims.
 - do not use mid-dot dividers in public copy or interface labels.
+- never use litotes or negative comparison frames in public copy. state the intended claim directly.
 - repeat context only when it changes understanding or supports a deliberate editorial rhythm. remove labels that restate the title, route, or surrounding section.
 - preserve compatibility paths through 2026-11-05. legacy changes are limited to security, data-loss, and installation blockers.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ this repository is an opinionated, source-backed handbook for experienced coding
 - prefer primary sources and record them in `docs/sources.json`.
 - do not use generated activity, commit frequency, or vendor benchmarks as evidence of quality.
 - keep the voice direct, lowercase, and professional. avoid hype, fan language, and unsupported authority claims.
+- do not use mid-dot dividers in public copy or interface labels.
+- never use litotes or negative comparison frames in public copy. state the intended claim directly.
+- repeat context only when it changes understanding or supports a deliberate editorial rhythm. remove labels that restate the title, route, or surrounding section.
 - preserve compatibility paths through 2026-11-05. legacy changes are limited to security, data-loss, and installation blockers.
 
 ## verification

--- a/docs/claude-code/README.md
+++ b/docs/claude-code/README.md
@@ -26,7 +26,7 @@ evidenceRail:
 
 primary source: [official claude code documentation](https://code.claude.com/docs/en)
 
-local note: 2.1.220 is installed, but the current hands-on protocol in [methodology](/method/) has not been rerun for this reset. recommendations below that depend on current product behavior are therefore source-verified rather than presented as fresh comparative testing.
+local note: 2.1.220 is installed. the current hands-on protocol in [methodology](/method/) remains pending for this reset, so recommendations that depend on current product behavior use source-verified evidence.
 
 ## current shape
 
@@ -85,7 +85,7 @@ third-party plugins run with meaningful local access. review their hooks, comman
 
 claude code desktop combines chats, diffs, previews, files, plans, tasks, terminals, and subagent views. this can reduce the attention cost of moving among a terminal, browser, editor, and pull-request page.
 
-the benefit is supervision, not lower compute use. several local sessions can still duplicate worktrees, dependencies, build processes, file watchers, browser instances, and model requests.
+the desktop benefit is supervision. compute use can still grow as local sessions duplicate worktrees, dependencies, build processes, file watchers, browser instances, and model requests.
 
 ## permissions and safety
 
@@ -97,7 +97,7 @@ permission mode, sandboxing, hooks, managed policy, and operating-system access 
 - inspect plugin and mcp provenance before granting access.
 - preserve user approval for destructive or difficult-to-reverse actions.
 
-hooks are useful enforcement, but a hook only covers events and payloads it actually receives. do not describe a hook as a complete security boundary without testing bypasses and failure behavior.
+treat each hook as enforcement for the events and payloads it receives. test bypasses and failure behavior before assigning it responsibility for a security boundary.
 
 ## memory and session continuity
 

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -52,7 +52,7 @@ use the smallest durable surface that matches the rule:
 | mechanical lifecycle enforcement | hook |
 | recurring background work | scheduled task in the desktop or web surface |
 
-keep required team rules in version control. memory is useful recall, not the only copy of a constraint that must always apply.
+keep required team rules in version control. use memory for recall and checked-in files for constraints that must always apply.
 
 ## the working loop
 
@@ -69,7 +69,7 @@ codex responds well to an explicit terminal condition: what must be true, what p
 
 the desktop app can create codex-managed worktrees for parallel chats. this is usually the cleanest local default when two tasks should produce independent diffs.
 
-worktrees isolate tracked files and branches. they do not eliminate shared resources. package caches, local databases, ports, browser profiles, running services, and external accounts can still collide.
+worktrees isolate tracked files and branches. package caches, local databases, ports, browser profiles, running services, and external accounts remain shared and can still collide.
 
 use subagents for read-heavy parallel work such as repository exploration, test triage, source research, or independent review. use separate worktrees when agents need to edit independently or run conflicting application instances.
 
@@ -84,7 +84,7 @@ choose the surface by the next review action:
 - use the ide extension when selection context, debugging, and inline diffs dominate.
 - use cloud work when the task benefits from isolation or should continue without the local machine.
 
-changing surfaces can preserve the same project context, but it does not guarantee identical tools or permissions. verify the effective environment after a handoff.
+changing surfaces can preserve project context while tools and permissions vary. verify the effective environment after a handoff.
 
 ## permissions and automation
 
@@ -104,7 +104,7 @@ local codex memories can summarize useful context from eligible prior chats. the
 
 use memory for preferences, recurring context, and useful recall. use `AGENTS.md`, checked-in docs, config, or a skill for requirements another engineer must be able to inspect and reproduce.
 
-review generated memory before sharing codex state. secret redaction reduces risk but does not make the entire state directory appropriate for publication.
+review generated memory before sharing codex state. publish purpose-selected excerpts after redaction because the state directory can contain private context beyond secrets.
 
 ## where older comparisons went wrong
 

--- a/docs/field-lab/README.md
+++ b/docs/field-lab/README.md
@@ -20,7 +20,7 @@ evidenceRail:
 
 the field lab evaluates coding-agent systems through repeatable engineering work.
 it measures what the operator must understand, supervise, recover, and verify.
-it does not produce a single winner score.
+its output is comparable run evidence rather than a single winner score.
 
 ## protocol
 
@@ -57,20 +57,20 @@ run records conform to the repository [run schema](https://github.com/anipotts/c
 include commits, pull requests, test logs, screenshots, and concise design-review
 notes.
 
-the following never belongs in a public run:
+exclude these from every public run:
 
 - raw chat or agent transcripts.
 - credentials, environment values, or account identifiers.
 - private repository names or private absolute paths.
 - personal data unrelated to the engineering result.
-- inferred token cost when the product did not expose it.
+- inferred token cost when the product leaves it unavailable.
 - a success claim without evidence from the layer it describes.
 
 ## interpretation
 
 elapsed time is useful only with operator interventions and review time beside it.
-tool-call count can describe a run, but it does not establish quality. resource
+tool-call count can describe a run. quality requires review evidence from the resulting work. resource
 measurements must identify what ran locally and what remained provider-hosted.
 
 comparative conclusions require comparable runs. a missing run remains visible as
-`pending`; it is not filled from documentation or remembered product behavior.
+`pending` until comparable hands-on evidence exists.

--- a/docs/field-lab/runs/README.md
+++ b/docs/field-lab/runs/README.md
@@ -3,7 +3,7 @@
 | run | status | evidence |
 |---|---|---|
 | codex v4 publication baseline | in progress | added after implementation verification |
-| claude code v4 publication baseline | pending | no current hands-on claim |
+| claude code v4 publication baseline | pending | current hands-on run pending |
 
 run records are immutable observations. corrections add a note or replacement run
 instead of silently changing the original outcome.

--- a/docs/field-lab/runs/codex-publication-baseline-2026-08-07.json
+++ b/docs/field-lab/runs/codex-publication-baseline-2026-08-07.json
@@ -67,7 +67,7 @@
       "evidence": [
         "https://github.com/anipotts/coding-agent-tips/tree/main/docs/decisions"
       ],
-      "notes": "decisions were persisted in signed commits and repository documents; a separate resumed-session recovery was not run"
+      "notes": "decisions were persisted in signed commits and repository documents; resumed-session recovery remains pending"
     },
     {
       "id": "delegated-analysis",
@@ -83,7 +83,7 @@
       "result": "not-run",
       "elapsedSeconds": null,
       "evidence": [],
-      "notes": "the implementation used the existing dedicated branch and checkout; a second worktree was not provisioned"
+      "notes": "the implementation used the existing dedicated branch and checkout; the second-worktree scenario remains pending"
     },
     {
       "id": "final-review",
@@ -145,10 +145,10 @@
     "machine name and account identifiers"
   ],
   "limitations": [
-    "the public run surface did not expose a model identifier",
-    "start time, scenario durations, memory capacity, and review time were not captured and remain null",
-    "token use and cost were not exposed and are not estimated",
-    "delegated analysis and a separate isolated-worktree scenario were not run",
+    "the model identifier was unavailable on the public run surface",
+    "available measurements exclude start time, scenario durations, memory capacity, and review time",
+    "available evidence excludes token use and cost estimates",
+    "delegated analysis and a separate isolated-worktree scenario remain pending",
     "the paired current claude code run remains pending",
     "production hosting, custom-domain behavior, and github metadata are outside this local baseline"
   ]

--- a/docs/legacy-tools.md
+++ b/docs/legacy-tools.md
@@ -12,7 +12,7 @@ evidenceRail:
     section: why-the-tools-are-retiring
     sourceId: anthropic-features-overview
   - kind: unknown
-    label: no automatic migration parity
+    label: manual migration review
     section: migration
 ---
 
@@ -51,7 +51,7 @@ the useful ideas have moved into first-party products or are better expressed as
 - transcript analytics require careful retention, privacy, and schema ownership.
 - resource estimates derived from undocumented client state are fragile.
 
-the plugin code remains useful as an implementation record. it is no longer the public center of the repository.
+the plugin code remains useful as an implementation record. the active guide carries the repository's current direction.
 
 ## migration
 
@@ -62,7 +62,7 @@ the plugin code remains useful as an implementation record. it is no longer the 
 | `time` meters | provider usage surfaces and smaller, reviewable task boundaries |
 | safety hooks | current native hooks, sandboxing, permission rules, and managed policy |
 
-there is no automatic migration that preserves every behavior. export any data you want to keep and review it for sensitive content before moving or sharing it.
+migration requires behavior-by-behavior review. export any data you want to keep and review it for sensitive content before moving or sharing it.
 
 ## end of window
 

--- a/docs/market/README.md
+++ b/docs/market/README.md
@@ -21,7 +21,7 @@ evidenceRail:
     section: contender-map
 ---
 
-this appendix helps experienced builders choose an operating environment. it does not rank model benchmark scores.
+this appendix helps experienced builders choose an operating environment through workflow and operating-model evidence.
 
 ## choose the layer first
 
@@ -86,17 +86,17 @@ default: evaluate opencode before building a custom harness. evaluate kimi code,
 | [kimi code](https://www.kimi.com/code/docs/) | terminal and ide harness optimized for kimi models | source-verified watchlist | separate from the Kimi K3 model family |
 | [qwen code](https://github.com/QwenLM/qwen-code) | open-source terminal and ide-friendly harness | source-verified watchlist | separate from Qwen model releases |
 | [grok build](https://docs.x.ai/build/overview) | open-source terminal harness with dashboard and acp support | source-verified watchlist | xai's coding harness; separate from Grok 4.5 |
-| [Kimi K3](https://github.com/MoonshotAI/Kimi-K3) | hosted and open-weight model family | source-verified watchlist | model layer, not an ide |
+| [Kimi K3](https://github.com/MoonshotAI/Kimi-K3) | hosted and open-weight model family | source-verified watchlist | model layer |
 | [Qwen models](https://github.com/QwenLM) | hosted and open-weight model family | source-verified watchlist | model layer, commonly used through Qwen Code or compatible harnesses |
 | [Grok 4.5](https://docs.x.ai/developers/grok-4-5) | hosted xai model | source-verified watchlist | model layer; available through Grok Build, api, and Cursor |
 
-cline and continue are intentionally outside this edition. absence does not imply a negative recommendation.
+cline and continue are outside this edition and remain unevaluated here.
 
 ## xai naming
 
 xai's first-party coding product is [Grok Build](https://docs.x.ai/build/overview), a terminal agent that can also run headlessly or through the Agent Client Protocol. [Grok 4.5](https://docs.x.ai/developers/grok-4-5) is the model used by that harness and is also offered in Cursor.
 
-current primary sources do not establish a separate xai-built Cursor-style editor. describe the harness and model separately until such a product is documented.
+current primary sources establish xai's model and harness layers. evaluate them separately while evidence for an xai-built Cursor-style editor remains absent.
 
 ## costs that pricing pages miss
 

--- a/docs/market/hardware.md
+++ b/docs/market/hardware.md
@@ -15,7 +15,7 @@ evidenceRail:
     section: ssd-pressure
     sourceId: git-worktrees
   - kind: inference
-    label: planning bands, not benchmarks
+    label: practical planning bands
     section: memory-planning-bands
 ---
 
@@ -30,11 +30,11 @@ coding-agent hardware cost depends on where inference runs and how much developm
 | local model, local agent | your machine | your machine | model weights, key-value cache, runtime memory, builds, and thermal load |
 | hosted model, many local agents | provider | your machine | duplicated workspaces and simultaneous development processes |
 
-using a hosted model does not make the workflow resource-free. it removes model inference from the mac while leaving the repository workload local.
+hosted inference moves model compute away from the mac while repository work remains local.
 
 ## memory planning bands
 
-these are practical planning bands for a modern mac, not universal requirements:
+use these practical planning bands as a starting point for a modern mac, then measure the actual development stack:
 
 | unified memory | reasonable expectation |
 |---|---|
@@ -55,7 +55,7 @@ a useful estimate is:
 workspace storage = base repository + worktrees × (dependencies + build output + local state)
 ```
 
-shared package caches reduce downloads but do not guarantee shared installed dependencies. measure one prepared worktree before assuming that ten parallel tasks will fit.
+shared package caches reduce downloads while installed dependencies may still duplicate. measure one prepared worktree before assuming that ten parallel tasks will fit.
 
 local model storage starts with model weights:
 
@@ -110,4 +110,4 @@ the wrong surface can increase cognitive load even when it saves clicks. evaluat
 
 for hosted codex or claude code use, prioritize enough memory for the development stack and enough ssd for several prepared worktrees. move beyond that baseline when measurements show sustained memory pressure, swap, thermal throttling, or storage churn.
 
-for local inference, choose the target model sizes and context requirements first. calculate weight and cache needs, then select hardware. a large memory specification without adequate bandwidth, cooling, or supported runtimes does not guarantee a useful coding-agent experience.
+for local inference, choose the target model sizes and context requirements first. calculate weight and cache needs, then select hardware. a useful coding-agent experience also depends on bandwidth, cooling, and supported runtimes.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -37,7 +37,7 @@ use sources in this order:
 3. reproducible local observation.
 4. third-party reporting for context, clearly identified.
 
-product pricing and availability can change quickly. link to the live official page instead of copying a large table when a static value is not essential to the decision.
+product pricing and availability can change quickly. reserve copied static values for decisions that require them; otherwise link to the live official page.
 
 ## freshness
 
@@ -52,7 +52,7 @@ the source registry uses these review windows:
 
 an upstream version change triggers review even when a page remains inside its time window.
 
-the freshness workflow is intentionally read-only. it reports drift by failing with a concise summary. it cannot commit content, update state, open issues, or merge changes.
+the freshness workflow has read-only permissions and reports drift through a concise failed check. publication remains a human-reviewed workflow.
 
 ## hands-on protocol
 
@@ -67,7 +67,7 @@ the same disposable repository should be used to evaluate a primary coding harne
 7. exercise permission denial, interruption, and a failed command.
 8. review the final diff and completion evidence from the product surface.
 
-record the product version, model, reasoning setting, machine, surface, repository state, elapsed time, and failures. one successful demo is not enough to make a reliability claim.
+record the product version, model, reasoning setting, machine, surface, repository state, elapsed time, and failures. reliability claims require repeated, comparable evidence.
 
 ## editorial standard
 
@@ -79,5 +79,6 @@ the guide is opinionated, but the reasoning must remain inspectable.
 - unknowns stay visible.
 - products are compared at the same layer.
 - personal taste is stated directly instead of being disguised as consensus.
-- labels do not restate a title, route, or surrounding section unless the repetition improves understanding.
-- mid-dot dividers do not appear in public copy or interface labels.
+- repeat a title, route, or surrounding label only when the repetition improves understanding.
+- omit mid-dot dividers from public copy and interface labels.
+- state claims directly and omit litotes or negative comparison frames.

--- a/docs/shared/operating-system.md
+++ b/docs/shared/operating-system.md
@@ -16,7 +16,7 @@ evidenceRail:
     section: use-evidence-to-resolve-uncertainty
   - kind: inference
     label: cross-runtime principles
-    section: review-the-system-not-only-the-diff
+    section: review-the-whole-system
 ---
 
 codex and claude code expose different native controls. the durable engineering principles underneath them are similar.
@@ -57,7 +57,7 @@ plans should name these checks. otherwise a detailed plan can still be speculati
 
 use one branch or worktree per independently reviewable change. parallel agents need explicit ownership of files, subsystems, or responsibilities.
 
-git isolation does not isolate runtime resources. check ports, databases, local services, browser profiles, caches, generated files, and external accounts before running several implementations at once.
+git isolation covers tracked files and branches. runtime resources remain shared, so check ports, databases, local services, browser profiles, caches, generated files, and external accounts before running several implementations at once.
 
 ## keep the main thread clean
 
@@ -82,7 +82,7 @@ a credible completion report states:
 
 - what changed.
 - what was tested.
-- what was not tested.
+- untested scope.
 - what remains gated or uncertain.
 
 avoid using a generated file, passing unit test, green deployment job, or visible preview as proof of a different layer. each claim needs evidence from the layer it describes.
@@ -93,7 +93,7 @@ chat memory is convenient and private to a runtime. another engineer should be a
 
 a useful handoff records the goal, changed files or commits, verification, unresolved decisions, and the next safe action. avoid copying full transcripts into a public repository.
 
-## review the system, not only the diff
+## review the whole system
 
 agent-generated code should be reviewed for:
 
@@ -104,4 +104,4 @@ agent-generated code should be reviewed for:
 - whether the verification actually proves the claim.
 - whether the change is easier to understand than the system it replaces.
 
-the same standard applies to agent infrastructure. a large control plane is not automatically more capable than a small, well-understood workflow.
+the same standard applies to agent infrastructure. a small, well-understood workflow can outperform a large control plane.

--- a/examples/agents/try-worktree.md
+++ b/examples/agents/try-worktree.md
@@ -79,4 +79,4 @@ drop in `.claude/agents/try-worktree.md` then:
 
 **pattern**: worktree isolation: your working tree stays completely clean. if the experiment is a disaster, nothing happened. if it works, you have a branch to merge.
 
-sonnet bc comparing approaches requires judgment, not just execution.
+sonnet bc comparing approaches requires judgment alongside execution.

--- a/examples/agents/write-pr.md
+++ b/examples/agents/write-pr.md
@@ -24,7 +24,7 @@ You are write-pr, a PR description writer. You read git diffs and write descript
 ## Your voice
 
 - Direct and conversational, not corporate
-- Explain the WHY, not just the what
+- Explain the WHY and connect it to the concrete change
 - If there's a tradeoff or known limitation, say it upfront
 - Use lowercase, skip trailing periods on bullet points
 - No "This PR..." openers. Just get into it
@@ -57,7 +57,7 @@ You are write-pr, a PR description writer. You read git diffs and write descript
 
 - Read the actual diff, don't guess
 - If mechanical (rename, format), say so briefly
-- If bug fix, explain the bug not just the fix
+- For a bug fix, explain the bug and the fix
 - Group by intent, not by file
 - Keep under 300 words unless genuinely complex
 - Never invent changes not in the diff

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,6 +2,6 @@
 
 `cc`, `lore`, and `time` are frozen through 2026-11-05. the compatibility window covers validated security issues, data-loss risks, current claude code compatibility breaks, and installation blockers.
 
-the plugins remain available so existing users can migrate deliberately. they are not the active direction of the repository, and no codex ports are planned.
+the plugins remain available so existing users can migrate deliberately. the active guide defines the repository's current direction, and the retirement plan excludes codex ports.
 
 read [legacy tools](../docs/legacy-tools.md) before installing.

--- a/plugins/cc/README.md
+++ b/plugins/cc/README.md
@@ -38,8 +38,8 @@ cc({ action: "check" })
 
 ## how awareness works (the gmail-cc metaphor)
 
-cc is the email cc line for claude code sessions. you're *informed*, not
-*obligated*. when another session does something relevant, you see it in
+cc is the email cc line for claude code sessions. it keeps you informed while
+you retain control. when another session does something relevant, you see it in
 context when you start your next turn. you decide whether to act.
 
 when you call `cc(action='check')`, cc returns an awareness digest: direct

--- a/plugins/cc/eval/README.md
+++ b/plugins/cc/eval/README.md
@@ -88,12 +88,10 @@ slash commands only run in interactive Claude Code.
 - `peer.callAction()` returns both parsed result AND round-trip ms.
   scenarios should record the ms via `h.recordSample(label, ms)` so it
   surfaces in the bench-mode distribution.
-- `h.waitFor(label, predicate)` returns the actual converge time, not
-  a deadline. scenarios assert against the recorded ms, not against
-  the predicate alone.
+- `h.waitFor(label, predicate)` returns the actual converge time. scenarios
+  assert against the recorded milliseconds and the predicate result.
 - `--bench N` runs each scenario N times in fresh dirs. samples
-  accumulate; percentiles come from real data, not single-sample
-  illusions.
+  accumulate into measured percentile distributions.
 
 ## known limitations
 

--- a/plugins/lore/README.md
+++ b/plugins/lore/README.md
@@ -92,7 +92,7 @@ You can also set it per-project in `.claude/settings.json` (project) or `.claude
 
 ### environment variables
 
-`cleanupPeriodDays` is a settings.json field, not an environment variable. CC does not currently expose an env-var override for it. If a future CC release adds one (e.g., `CLAUDE_CODE_CLEANUP_PERIOD_DAYS`), this README will be updated to mention it.
+`cleanupPeriodDays` currently loads from `settings.json`. If a future CC release adds an environment-variable override (for example, `CLAUDE_CODE_CLEANUP_PERIOD_DAYS`), this README will document it.
 
 ### verify your setting
 

--- a/src/pages/field-lab/runs/[runId].astro
+++ b/src/pages/field-lab/runs/[runId].astro
@@ -37,9 +37,9 @@ export function getStaticPaths() {
 }
 
 const { run } = Astro.props as { run: FieldRun };
-const display = (value: string | number | null) => value ?? 'not recorded';
+const display = (value: string | number | null) => value ?? 'unavailable';
 const statusLabel = { complete: 'complete', partial: 'partially complete', pending: 'planned' }[run.status];
-const resultLabel = { pass: 'passed', fail: 'needs work', partial: 'partial', 'not-run': 'not run' };
+const resultLabel = { pass: 'passed', fail: 'needs work', partial: 'partial', 'not-run': 'pending' };
 const completedDate = run.completedAt ? run.completedAt.slice(0, 10) : null;
 const artifactLabel = (kind: string) => kind.replaceAll('-', ' ');
 ---
@@ -82,7 +82,7 @@ const artifactLabel = (kind: string) => kind.replaceAll('-', ' ');
 
     <section class="run-grid">
       <div><div class="run-section-heading"><p>03 / machine</p><h2>the machine behind the run</h2></div><dl class="compact-data"><div><dt>platform</dt><dd>{run.machineProfile.platform}</dd></div><div><dt>architecture</dt><dd>{run.machineProfile.architecture}</dd></div><div><dt>memory</dt><dd>{display(run.machineProfile.memoryGb)}</dd></div><div><dt>notes</dt><dd>{run.machineProfile.notes}</dd></div></dl></div>
-      <div><div class="run-section-heading"><p>04 / limits</p><h2>what this run couldn't prove</h2></div><ul>{run.limitations.map((limitation) => <li>{limitation}</li>)}</ul></div>
+      <div><div class="run-section-heading"><p>04 / limits</p><h2>open questions from this run</h2></div><ul>{run.limitations.map((limitation) => <li>{limitation}</li>)}</ul></div>
     </section>
 
     <section aria-labelledby="redaction-title">


### PR DESCRIPTION
## why

the launch copy still used litotes and negative comparison frames in several guides, evidence labels, run notes, and compatibility pages. direct claims make the reasoning easier to scan and easier to defend.

## changes

- rewrites the active codex, claude code, market, hardware, methodology, field lab, and operating-system copy
- gives unavailable field-run values and pending scenarios clearer reader-facing labels
- aligns reader-facing examples and frozen compatibility documentation with the same voice
- records the rule in both agent guides, the public methodology, and the validation workflow

## verification

- field-run schema and 18-source registry validation
- Astro type checking, 13-page production build, and 12-route generated-site tests
- Markdown lint, workflow YAML parsing, diff checks, and the repository-wide litotes scan
- 45 cc tests and 175 lore tests during the compatibility window

## boundaries

historical changelogs retain their original wording. direct safety prohibitions and factual pending or unavailable states remain precise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified guidance for evidence-based testing, worktree isolation, handoffs, memory review, migration planning, and hardware selection.
  - Updated field-lab and publication records to distinguish measured evidence, pending validation, unavailable metrics, and open questions.
  - Refined market, operating-system, plugin, and evaluation documentation for clearer expectations and terminology.

- **Style**
  - Added editorial standards favoring direct claims and consistent labels.
  - Improved wording across examples and user-facing run details.

- **Quality**
  - Added validation to flag prohibited negative-comparison phrasing in tracked Markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->