### PR TITLE
docs: refine homepage agent-system taxonomy

### DIFF
--- a/scripts/test-site.mjs
+++ b/scripts/test-site.mjs
@@ -6,6 +6,15 @@ const root = process.cwd();
 const dist = path.join(root, 'dist');
 const origin = 'https://agents.anipotts.com';
 const canonicalH1 = 'a guide to coding agents in production software (projects, startups & big tech)';
+const requiredHomepageCopy = [
+  'understand the layers of every agentic system',
+  "it's important to know which layer holds the solution space to your bottlenecks",
+  'cli, ide & app tradeoffs',
+  'tools, runtime & memory',
+  'valuing inference',
+  'how parallel work is planned & coordinated',
+  'compare setups most commonly used',
+];
 const requiredRoutes = [
   '/',
   '/guides/',
@@ -68,11 +77,19 @@ for (const route of requiredRoutes) {
 }
 
 const home = await readFile(routeFile('/'), 'utf8');
+const homeText = home
+  .replace(/<[^>]+>/g, ' ')
+  .replaceAll('&amp;', '&')
+  .replace(/\s+/g, ' ')
+  .trim();
 const h1Values = [...home.matchAll(/<h1\b[^>]*>(.*?)<\/h1>/gs)].map((match) =>
   match[1].replace(/<[^>]+>/g, '').replaceAll('&amp;', '&').trim(),
 );
 if (h1Values.length !== 1 || h1Values[0] !== canonicalH1) {
   failures.push(`/: expected one exact canonical h1, received ${JSON.stringify(h1Values)}`);
+}
+for (const copy of requiredHomepageCopy) {
+  if (!homeText.includes(copy)) failures.push(`/: annotated homepage copy is missing: ${copy}`);
 }
 
 for (const route of ['/', '/field-lab/runs/codex-publication-baseline-2026-08-07/']) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,25 +9,25 @@ const layers = [
   {
     icon: 'ph:app-window',
     name: 'surface',
-    description: 'where you steer and review',
+    description: 'cli, ide & app tradeoffs',
     examples: 'terminal, desktop app, ide, web',
   },
   {
     icon: 'ph:terminal-window',
     name: 'harness',
-    description: 'the coding-agent runtime',
+    description: 'tools, runtime & memory',
     examples: 'codex, claude code, qwen code',
   },
   {
     icon: 'ph:brain',
     name: 'model',
-    description: 'the inference layer',
+    description: 'valuing inference',
     examples: 'hosted, open-weight, local',
   },
   {
     icon: 'ph:git-branch',
     name: 'orchestration',
-    description: 'how parallel work is coordinated',
+    description: 'how parallel work is planned & coordinated',
     examples: 'worktrees, agents, control planes',
   },
 ];
@@ -64,8 +64,8 @@ const guides = [
     <section class="taxonomy page-band" aria-labelledby="taxonomy-title">
       <header class="section-heading">
         <p>01 / taxonomy</p>
-        <h2 id="taxonomy-title">name the layer before comparing the tool</h2>
-        <p>a surface, harness, model, and orchestration layer solve different parts of the system.</p>
+        <h2 id="taxonomy-title">understand the layers of every agentic system</h2>
+        <p>it's important to know which layer holds the solution space to your bottlenecks</p>
       </header>
       <div class="layer-grid">
         {
@@ -85,7 +85,7 @@ const guides = [
     <section class="page-band models" aria-labelledby="model-title">
       <header class="section-heading">
         <p>02 / operating models</p>
-        <h2 id="model-title">choose for the review loop you actually run</h2>
+        <h2 id="model-title">compare setups most commonly used</h2>
       </header>
       <div class="model-table">
         <div class="model-head" aria-hidden="true"><span>system</span><span>advantage</span><span>cost</span><span></span></div>


### PR DESCRIPTION
## what changed

- revised the homepage taxonomy heading and bottleneck framing from Ani's browser annotations
- clarified surface, harness, model, and orchestration as setup decisions readers can evaluate
- renamed the operating-model comparison section
- added a generated-site regression check for all seven annotated strings

## why

the prior labels described the architecture accurately but stayed abstract. the revised language connects each layer to the decisions a reader makes when selecting or operating a coding-agent system.

where duplicate annotations proposed different text, this change uses the latest wording from the same review session.

## responsive behavior

this is a copy-only change. the existing four-column desktop grid and stacked mobile layout continue to own wrapping, so no viewport-specific styling or temporary preview attributes were added.

## verification

- `bun run check`
- `bun run build`
- `bun run test:site`
- `bun run check:field-runs`
- `python3 .github/scripts/check_sources.py`
- `bun test plugins/cc/tests` with 45 passing tests
- `python3 -m pytest plugins/lore/tests` with 175 passing tests
- markdownlint with 0 issues
- json, python, shell, and git diff validation

## remaining ci proof

local chromium could not start because macos denied its mach rendezvous service. the github actions accessibility job is the authoritative browser and responsive check for this pr.