### PR TITLE
ci: publish reviewed release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           git rev-parse "refs/tags/$RELEASE_TAG" >/dev/null
           test "$RELEASE_TAG" = "v4.0.0" || [[ "$RELEASE_TAG" == legacy-tools-final-* ]]
+          test -f "docs/releases/$RELEASE_TAG.md"
 
       - name: publish existing tag
         env:
@@ -37,7 +38,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          args=("$RELEASE_TAG" --verify-tag --generate-notes --title "$RELEASE_TAG")
+          args=("$RELEASE_TAG" --verify-tag --notes-file "docs/releases/$RELEASE_TAG.md" --title "$RELEASE_TAG")
           if [ "$PRERELEASE" = "true" ]; then
             args+=(--prerelease)
           fi


### PR DESCRIPTION
## what changed

- require a repository release document for every allowed manual release tag
- publish that reviewed document with `--notes-file`
- preserve the existing tag verification and prerelease behavior

## why

the workflow previously ignored `docs/releases/v4.0.0.md` and generated generic notes at publication time. that broke the launch plan's human-authored release contract.

## impact

`v4.0.0` will publish the professional notes already reviewed in the repository. the November legacy-final release will also require its own reviewed notes before publication.

## verification

- parsed `.github/workflows/release.yml` with PyYAML
- confirmed `docs/releases/v4.0.0.md` exists
- `git diff --check`

`actionlint` is unavailable locally, so GitHub Actions is the authoritative workflow parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release notes are now provided from a dedicated release notes file for each release.
  * Releases use the supplied notes instead of automatically generated release descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->