### PR TITLE
docs: refresh claude code sources for 2.1.227

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,11 +2,15 @@
 title: latest changes
 description: material changes to the guide, its evidence, and its recommendations.
 products: [cross-runtime]
-lastVerified: 2026-08-09
+lastVerified: 2026-08-10
 status: current
 evidence: [hands-on, source-verified]
-sources: [openai-codex-manual, anthropic-claude-overview]
+sources: [openai-codex-manual, anthropic-claude-overview, anthropic-changelog]
 evidenceRail:
+  - kind: source-verified
+    label: claude code 2.1.226 review
+    section: '2026-08-10'
+    sourceId: anthropic-changelog
   - kind: hands-on
     label: publication shell review
     section: '2026-08-09'
@@ -22,6 +26,19 @@ evidenceRail:
     label: v4 publication reset
     section: '2026-08-07'
 ---
+
+## 2026-08-10
+
+### claude code source refresh
+
+- verified package 2.1.226 against the current official changelog.
+- recorded the 2.1.225 workspace trust prompt for `claude agents`.
+- documented named remote control session messaging across machines.
+- kept the hands-on claude code field run visibly pending.
+
+### repository signal
+
+- confirmed the published 27-star count against the renamed github repository.
 
 ## 2026-08-09
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,14 +2,14 @@
 title: latest changes
 description: material changes to the guide, its evidence, and its recommendations.
 products: [cross-runtime]
-lastVerified: 2026-08-10
+lastVerified: 2026-08-11
 status: current
 evidence: [hands-on, source-verified]
 sources: [openai-codex-manual, anthropic-claude-overview, anthropic-changelog]
 evidenceRail:
   - kind: source-verified
-    label: claude code 2.1.226 review
-    section: '2026-08-10'
+    label: claude code 2.1.227 review
+    section: '2026-08-11'
     sourceId: anthropic-changelog
   - kind: hands-on
     label: publication shell review
@@ -27,11 +27,11 @@ evidenceRail:
     section: '2026-08-07'
 ---
 
-## 2026-08-10
+## 2026-08-11
 
 ### claude code source refresh
 
-- verified package 2.1.226 against the current official changelog.
+- verified package 2.1.227 against the current official changelog.
 - recorded the 2.1.225 workspace trust prompt for `claude agents`.
 - documented named remote control session messaging across machines.
 - kept the hands-on claude code field run visibly pending.

--- a/docs/claude-code/README.md
+++ b/docs/claude-code/README.md
@@ -2,7 +2,7 @@
 title: claude code
 description: source-verified guidance for claude code terminal, desktop, ide, agents, hooks, and permissions.
 products: [claude-code]
-lastVerified: 2026-08-10
+lastVerified: 2026-08-11
 status: pending
 evidence: [source-verified, unknown]
 sources: [anthropic-claude-overview, anthropic-changelog, anthropic-features-overview, anthropic-desktop, anthropic-permissions, anthropic-memory, anthropic-remote-control]
@@ -12,7 +12,7 @@ evidenceRail:
     section: current-shape
     sourceId: anthropic-claude-overview
   - kind: source-verified
-    label: claude code 2.1.226 source refresh
+    label: claude code 2.1.227 source refresh
     section: current-shape
     sourceId: anthropic-changelog
   - kind: source-verified
@@ -38,7 +38,7 @@ evidenceRail:
 
 source review: [official claude code documentation](https://code.claude.com/docs/en) and the [2.1.225 release notes](https://code.claude.com/docs/en/changelog#2-1-225). section citations point to the exact references.
 
-the source review tracks package 2.1.226. the current hands-on protocol in [methodology](/method/) remains pending for this reset, so recommendations that depend on current product behavior use source-verified evidence.
+the source review tracks package 2.1.227. the current hands-on protocol in [methodology](/method/) remains pending for this reset, so recommendations that depend on current product behavior use source-verified evidence.
 
 ## current shape
 

--- a/docs/claude-code/README.md
+++ b/docs/claude-code/README.md
@@ -2,15 +2,19 @@
 title: claude code
 description: source-verified guidance for claude code terminal, desktop, ide, agents, hooks, and permissions.
 products: [claude-code]
-lastVerified: 2026-08-07
+lastVerified: 2026-08-10
 status: pending
 evidence: [source-verified, unknown]
-sources: [anthropic-claude-overview, anthropic-features-overview, anthropic-desktop]
+sources: [anthropic-claude-overview, anthropic-changelog, anthropic-features-overview, anthropic-desktop, anthropic-permissions, anthropic-memory, anthropic-remote-control]
 evidenceRail:
   - kind: source-verified
     label: claude code overview
     section: current-shape
     sourceId: anthropic-claude-overview
+  - kind: source-verified
+    label: claude code 2.1.226 source refresh
+    section: current-shape
+    sourceId: anthropic-changelog
   - kind: source-verified
     label: current features
     section: skills-hooks-plugins-and-agents
@@ -19,18 +23,26 @@ evidenceRail:
     label: desktop documentation
     section: desktop-and-context-switch-cost
     sourceId: anthropic-desktop
+  - kind: source-verified
+    label: permission model
+    section: permissions-and-safety
+    sourceId: anthropic-permissions
+  - kind: source-verified
+    label: memory and remote control
+    section: memory-and-session-continuity
+    sourceId: anthropic-memory
   - kind: unknown
     label: current hands-on rerun pending
     section: professional-default
 ---
 
-primary source: [official claude code documentation](https://code.claude.com/docs/en)
+source review: [official claude code documentation](https://code.claude.com/docs/en) and the [2.1.225 release notes](https://code.claude.com/docs/en/changelog#2-1-225). section citations point to the exact references.
 
-local note: 2.1.220 is installed. the current hands-on protocol in [methodology](/method/) remains pending for this reset, so recommendations that depend on current product behavior use source-verified evidence.
+the source review tracks package 2.1.226. the current hands-on protocol in [methodology](/method/) remains pending for this reset, so recommendations that depend on current product behavior use source-verified evidence.
 
 ## current shape
 
-claude code is a coding-agent system available through terminal, desktop, ide, web, and remote workflows.
+claude code is a coding-agent system available through terminal, desktop, ide, web, and remote workflows. remote control keeps execution on the host machine while exposing the running session through supported web and mobile surfaces. [official overview](https://code.claude.com/docs/en/overview) and [remote control](https://code.claude.com/docs/en/remote-control)
 
 | surface | best fit | main tradeoff |
 |---|---|---|
@@ -41,7 +53,7 @@ claude code is a coding-agent system available through terminal, desktop, ide, w
 
 ## durable configuration
 
-choose an extension point by how it should load:
+choose an extension point by how it should load. [features overview](https://code.claude.com/docs/en/features-overview) and [memory reference](https://code.claude.com/docs/en/memory)
 
 | need | claude code surface |
 |---|---|
@@ -77,19 +89,21 @@ these features solve different problems:
 - a plugin packages skills, hooks, subagents, mcp servers, and related configuration.
 - an agent team coordinates separate sessions that need shared tasks or peer communication.
 
-agent teams are experimental and disabled by default in current official guidance. use them when peers need to coordinate with each other. prefer a subagent when the main session only needs a focused result.
+agent teams are experimental and disabled by default in current official guidance. use them when peers need to coordinate with each other. prefer a subagent when the main session only needs a focused result. [features overview](https://code.claude.com/docs/en/features-overview)
 
 third-party plugins run with meaningful local access. review their hooks, commands, mcp servers, storage, and update path before installation.
 
 ## desktop and context-switch cost
 
-claude code desktop combines chats, diffs, previews, files, plans, tasks, terminals, and subagent views. this can reduce the attention cost of moving among a terminal, browser, editor, and pull-request page.
+claude code desktop combines chats, diffs, previews, files, plans, tasks, terminals, and subagent views. this can reduce the attention cost of moving among a terminal, browser, editor, and pull-request page. [desktop documentation](https://code.claude.com/docs/en/desktop)
 
 the desktop benefit is supervision. compute use can still grow as local sessions duplicate worktrees, dependencies, build processes, file watchers, browser instances, and model requests.
 
 ## permissions and safety
 
-permission mode, sandboxing, hooks, managed policy, and operating-system access are separate layers.
+permission mode, sandboxing, hooks, managed policy, and operating-system access are separate layers. [permissions reference](https://code.claude.com/docs/en/permissions)
+
+claude code 2.1.225 added a workspace trust prompt when `claude agents` starts in an untrusted directory. workspace trust controls whether the project can load; permission and sandbox policy still control what a running session may do. [2.1.225 release notes](https://code.claude.com/docs/en/changelog#2-1-225)
 
 - use narrow allow rules for routine commands.
 - keep bypass modes inside disposable or strongly isolated environments.
@@ -101,7 +115,9 @@ treat each hook as enforcement for the events and payloads it receives. test byp
 
 ## memory and session continuity
 
-claude code supports `CLAUDE.md`, auto memory, session resume, remote control, and desktop-managed sessions. these are complementary.
+claude code supports `CLAUDE.md`, auto memory, session resume, remote control, and desktop-managed sessions. these are complementary. [memory reference](https://code.claude.com/docs/en/memory) and [remote control](https://code.claude.com/docs/en/remote-control)
+
+as of 2.1.225, `SendMessage` can start a conversation with a named remote control session on another machine. use that for live routing between active sessions; keep durable project state in files, commits, and explicit handoffs. [2.1.225 release notes](https://code.claude.com/docs/en/changelog#2-1-225)
 
 use checked-in instructions for rules the team must share. use auto memory for learned local context. use session resume when the original conversation remains the right unit of work. use a written handoff when another person or runtime must continue without depending on hidden chat state.
 

--- a/docs/sources.json
+++ b/docs/sources.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "checked_on": "2026-08-10",
+  "checked_on": "2026-08-11",
   "product_versions": {
     "codex": "0.147.0",
-    "claude_code": "2.1.226"
+    "claude_code": "2.1.227"
   },
   "sources": [
     {
@@ -25,7 +25,7 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -38,7 +38,7 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en/changelog#2-1-225",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -55,7 +55,7 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en/features-overview",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -68,7 +68,7 @@
       "layer": "surface",
       "status": "core",
       "url": "https://code.claude.com/docs/en/desktop",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -81,7 +81,7 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en/permissions",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -98,7 +98,7 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en/memory",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -115,7 +115,7 @@
       "layer": "surface",
       "status": "core",
       "url": "https://code.claude.com/docs/en/remote-control",
-      "last_checked": "2026-08-10",
+      "last_checked": "2026-08-11",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",

--- a/docs/sources.json
+++ b/docs/sources.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "checked_on": "2026-08-07",
+  "checked_on": "2026-08-10",
   "product_versions": {
     "codex": "0.147.0",
-    "claude_code": "2.1.224"
+    "claude_code": "2.1.226"
   },
   "sources": [
     {
@@ -25,11 +25,28 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en",
-      "last_checked": "2026-08-07",
+      "last_checked": "2026-08-10",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
         "terms": ["Claude Code", "terminal", "IDE"]
+      }
+    },
+    {
+      "id": "anthropic-changelog",
+      "product": "claude-code",
+      "layer": "harness",
+      "status": "core",
+      "url": "https://code.claude.com/docs/en/changelog#2-1-225",
+      "last_checked": "2026-08-10",
+      "evidence": "source-verified",
+      "watch": {
+        "kind": "terms",
+        "terms": [
+          "workspace trust prompt",
+          "SendMessage",
+          "Remote Control"
+        ]
       }
     },
     {
@@ -38,7 +55,7 @@
       "layer": "harness",
       "status": "core",
       "url": "https://code.claude.com/docs/en/features-overview",
-      "last_checked": "2026-08-07",
+      "last_checked": "2026-08-10",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
@@ -51,11 +68,62 @@
       "layer": "surface",
       "status": "core",
       "url": "https://code.claude.com/docs/en/desktop",
-      "last_checked": "2026-08-07",
+      "last_checked": "2026-08-10",
       "evidence": "source-verified",
       "watch": {
         "kind": "terms",
         "terms": ["Claude Code on desktop", "worktree", "diff"]
+      }
+    },
+    {
+      "id": "anthropic-permissions",
+      "product": "claude-code",
+      "layer": "harness",
+      "status": "core",
+      "url": "https://code.claude.com/docs/en/permissions",
+      "last_checked": "2026-08-10",
+      "evidence": "source-verified",
+      "watch": {
+        "kind": "terms",
+        "terms": [
+          "fine-grained permissions",
+          "permission modes",
+          ".claude/settings.local.json"
+        ]
+      }
+    },
+    {
+      "id": "anthropic-memory",
+      "product": "claude-code",
+      "layer": "harness",
+      "status": "core",
+      "url": "https://code.claude.com/docs/en/memory",
+      "last_checked": "2026-08-10",
+      "evidence": "source-verified",
+      "watch": {
+        "kind": "terms",
+        "terms": [
+          "CLAUDE.md",
+          "Auto memory",
+          ".claude/rules/"
+        ]
+      }
+    },
+    {
+      "id": "anthropic-remote-control",
+      "product": "claude-code",
+      "layer": "surface",
+      "status": "core",
+      "url": "https://code.claude.com/docs/en/remote-control",
+      "last_checked": "2026-08-10",
+      "evidence": "source-verified",
+      "watch": {
+        "kind": "terms",
+        "terms": [
+          "Remote Control",
+          "research preview",
+          "running locally"
+        ]
       }
     },
     {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,5 +1,5 @@
 export const repository = {
   url: 'https://github.com/anipotts/coding-agent-tips',
   stars: 27,
-  starsVerifiedAt: '2026-08-10',
+  starsVerifiedAt: '2026-08-11',
 } as const;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,5 +1,5 @@
 export const repository = {
   url: 'https://github.com/anipotts/coding-agent-tips',
   stars: 27,
-  starsVerifiedAt: '2026-08-09',
+  starsVerifiedAt: '2026-08-10',
 } as const;


### PR DESCRIPTION
## rationale

the deterministic freshness check found Claude Code package drift from 2.1.224 to 2.1.227. the 2.1.225 release changes workspace trust for `claude agents` and cross-machine Remote Control messaging, so the guide needs more than a version-only registry edit. the 2.1.227 reliability release changes the verified package boundary without changing the operating recommendation.

## evidence and editorial decisions

- add exact official sources for the changelog, permissions, memory, and Remote Control
- cite material capability claims beside the relevant guidance
- keep the Claude Code hands-on field run visibly pending
- refresh the unchanged 27-star repository signal with today's verification date

primary evidence: [Claude Code 2.1.225 changelog](https://code.claude.com/docs/en/changelog#2-1-225), [Claude Code 2.1.227 changelog](https://code.claude.com/docs/en/changelog#2-1-227), [permissions](https://code.claude.com/docs/en/permissions), [memory](https://code.claude.com/docs/en/memory), and [Remote Control](https://code.claude.com/docs/en/remote-control).

## verification

- live freshness and structure checks across 22 sources
- Astro diagnostics, production build, and 12-route publication regression
- JSON, Python, and shell validation
- 45 cc tests and 175 lore tests
- rendered desktop and 375-pixel mobile QA
- expanded mobile evidence disclosure with seven entries, zero horizontal overflow, and zero console warnings or errors

local Playwright accessibility remains constrained by the macOS browser sandbox. the required Linux site check retains the accessibility gate.

## rollout

merge with a signed squash commit after the required site, handbook, markdown, and compatibility checks pass. verify the deployed Claude Code guide and changes page at the custom domain.