### PR TITLE
fix(site): derive current state from source metadata

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,10 @@
 ---
 title: latest changes
 description: material changes to the guide, its evidence, and its recommendations.
+latestChange:
+  date: 2026-08-11
+  title: "the evidence and toolchain stay current"
+  summary: "refreshed the claude code guide through 2.1.227 and updated the publication toolchain through an inspectable codex run."
 products: [cross-runtime]
 lastVerified: 2026-08-11
 status: current
@@ -39,6 +43,7 @@ evidenceRail:
 - added a [codex maintenance run](/field-lab/runs/codex-dependency-maintenance-2026-08-11/)
   with the task boundary, skipped scenarios, evidence, and limitations.
 - made the route regression suite discover every field-run page from its data file.
+- made the homepage latest-change section read from this changelog metadata.
 
 ### claude code source refresh
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#1247e6"/>
+  <path d="m17 20 13 12-13 12M34 44h13" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"/>
+</svg>

--- a/scripts/test-a11y.mjs
+++ b/scripts/test-a11y.mjs
@@ -1,14 +1,18 @@
 import { spawn } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
 import process from 'node:process';
 import AxeBuilder from '@axe-core/playwright';
 import { chromium } from '@playwright/test';
 
 const origin = 'http://127.0.0.1:4173';
+const fieldRunFiles = (await readdir(new URL('../docs/field-lab/runs/', import.meta.url)))
+  .filter((file) => file.endsWith('.json'))
+  .sort();
 const routes = [
   '/',
   '/guides/codex/',
   '/guides/claude-code/',
-  '/field-lab/runs/codex-publication-baseline-2026-08-07/',
+  ...fieldRunFiles.map((file) => `/field-lab/runs/${file.replace(/\.json$/, '')}/`),
 ];
 const viewports = [
   { name: 'mobile', width: 375, height: 812 },

--- a/scripts/test-site.mjs
+++ b/scripts/test-site.mjs
@@ -41,6 +41,23 @@ const routeFile = (route) =>
     ? path.join(dist, 'index.html')
     : path.join(dist, route.replace(/^\//, ''), 'index.html');
 const failures = [];
+try {
+  await access(path.join(root, 'public', 'favicon.svg'));
+} catch {
+  failures.push('favicon source is missing');
+}
+const changesSource = await readFile(path.join(root, 'docs', 'changes.md'), 'utf8');
+const latestChangeBlock = changesSource.match(/^latestChange:\n((?:  .*\n)+)/m)?.[1] ?? '';
+const latestChange = Object.fromEntries(
+  [...latestChangeBlock.matchAll(/^  (date|title|summary):\s*(.+)$/gm)].map((match) => {
+    const value = match[2].trim();
+    const unquoted = /^(["'])(.*)\1$/.exec(value)?.[2] ?? value;
+    return [match[1], unquoted];
+  }),
+);
+for (const field of ['date', 'title', 'summary']) {
+  if (!latestChange[field]) failures.push(`changes frontmatter is missing latestChange.${field}`);
+}
 
 for (const route of requiredRoutes) {
   const file = routeFile(route);
@@ -59,6 +76,9 @@ for (const route of requiredRoutes) {
   }
   if (!html.includes('<meta property="og:title"')) {
     failures.push(`${route}: open graph title is missing`);
+  }
+  if (!/<link\s+rel="(?:shortcut )?icon"\s+href="\/favicon\.svg"\s+type="image\/svg\+xml"\s*\/?\s*>/.test(html)) {
+    failures.push(`${route}: favicon metadata is missing`);
   }
   if (html.includes('·')) {
     failures.push(`${route}: mid-dot divider appears in public output`);
@@ -96,6 +116,14 @@ if (h1Values.length !== 1 || h1Values[0] !== canonicalH1) {
 }
 for (const copy of requiredHomepageCopy) {
   if (!homeText.includes(copy)) failures.push(`/: annotated homepage copy is missing: ${copy}`);
+}
+if (latestChange.date && !home.includes(`<time datetime="${latestChange.date}">${latestChange.date}</time>`)) {
+  failures.push('/: latest material change date does not match changes frontmatter');
+}
+for (const field of ['title', 'summary']) {
+  if (latestChange[field] && !homeText.includes(latestChange[field])) {
+    failures.push(`/: latest material change ${field} does not match changes frontmatter`);
+  }
 }
 
 for (const route of ['/', ...fieldRunRoutes]) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -42,6 +42,13 @@ const docs = defineCollection({
       status: z.enum(['current', 'pending', 'legacy']),
       evidence: z.array(evidenceKind),
       sources: z.array(z.string()),
+      latestChange: z
+        .object({
+          date: z.date(),
+          title: z.string(),
+          summary: z.string(),
+        })
+        .optional(),
       evidenceRail: z.array(
         z.object({
           kind: evidenceKind,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,6 +20,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="canonical" href={canonical} />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="coding agent tips" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,15 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { getEntry } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
 const title = 'coding agent tips';
 const description =
   'evidence-backed guidance for coding agents in production software, from individual projects to startups and big tech.';
+const changesEntry = await getEntry('docs', 'changes');
+const latestChange = changesEntry?.data.latestChange;
+if (!latestChange) throw new Error('changes frontmatter requires latestChange metadata');
+const latestChangeDate = latestChange.date.toISOString().slice(0, 10);
 const layers = [
   {
     icon: 'ph:app-window',
@@ -125,8 +130,8 @@ const guides = [
     </section>
 
     <section class="page-band changes-band" aria-labelledby="changes-title">
-      <header class="section-heading"><p>05 / latest material change</p><h2 id="changes-title">the repository becomes the publication</h2></header>
-      <div class="change-entry"><time datetime="2026-08-07">2026-08-07</time><p>introduced the layered market model, evidence contract, field lab, and paired codex and claude code guides.</p><a href="/changes/">read changes <Icon name="ph:arrow-right" aria-hidden="true" /></a></div>
+      <header class="section-heading"><p>05 / latest material change</p><h2 id="changes-title">{latestChange.title}</h2></header>
+      <div class="change-entry"><time datetime={latestChangeDate}>{latestChangeDate}</time><p>{latestChange.summary}</p><a href="/changes/">read changes <Icon name="ph:arrow-right" aria-hidden="true" /></a></div>
     </section>
   </main>
   <footer class="site-footer">


### PR DESCRIPTION
## rationale

the homepage latest-change block was hard-coded to the august 7 launch, so it drifted after the august 11 source and dependency work. the same production review found a browser request for a missing favicon and accessibility coverage tied to one field-run filename.

## what changed

- make the changes page frontmatter the homepage source of truth.
- declare one pinned svg favicon across the custom and starlight layouts.
- verify favicon metadata and latest-change parity in the static-site regression suite.
- discover every field run in the accessibility suite.

## verification

- `bun run check` and `bun run build`
- `bun run test:site` and `bun run check:field-runs`
- exact 375x812 and 1440x1024 browser checks with no horizontal overflow
- mobile and desktop lighthouse scores of 100 for accessibility, best practices, seo, and agentic browsing

## rollout

required github checks remain the merge gate. the local accessibility runner reached chromium launch, where macos denied the child process access to its mach port. github actions provides the authoritative browser result before merge.