### PR TITLE
fix: resolve drafts with publish permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      release-id: ${{ steps.release-input.outputs.release-id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: verify signed tag and reviewed draft
-        id: release-input
+      - name: verify signed tag
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
@@ -44,16 +41,6 @@ jobs:
             --jq '.verification')"
           test "$(jq -r '.verified' <<< "$tag_verification")" = "true"
           test "$(jq -r '.reason' <<< "$tag_verification")" = "valid"
-          release_json="$(gh api --paginate \
-            "repos/$GITHUB_REPOSITORY/releases?per_page=100" | \
-            jq -s --arg tag "$RELEASE_TAG" \
-              '[.[][] | select(.tag_name == $tag)] |
-               if length == 1 then .[0]
-               else error("expected exactly one release for tag " + $tag)
-               end')"
-          test "$(jq -r '.tag_name' <<< "$release_json")" = "$RELEASE_TAG"
-          test "$(jq -r '.draft' <<< "$release_json")" = "true"
-          echo "release-id=$(jq -r '.id' <<< "$release_json")" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: verify
@@ -65,12 +52,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_ID: ${{ needs.verify.outputs.release-id }}
         run: |
-          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          tag_ref="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG")"
+          test "$(jq -r '.object.type' <<< "$tag_ref")" = "tag"
+          tag_verification="$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/tags/$(jq -r '.object.sha' <<< "$tag_ref")" \
+            --jq '.verification')"
+          test "$(jq -r '.verified' <<< "$tag_verification")" = "true"
+          test "$(jq -r '.reason' <<< "$tag_verification")" = "valid"
+          release_json="$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" | \
+            jq -s --arg tag "$RELEASE_TAG" \
+              '[.[][] | select(.tag_name == $tag)] |
+               if length == 1 then .[0]
+               else error("expected exactly one release for tag " + $tag)
+               end')"
           test "$(jq -r '.tag_name' <<< "$release_json")" = "$RELEASE_TAG"
           test "$(jq -r '.draft' <<< "$release_json")" = "true"
+          release_id="$(jq -r '.id' <<< "$release_json")"
           gh api --method PATCH \
-            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" \
             -F draft=false >/dev/null
           echo "published the existing reviewed draft for $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## summary

- keep signed-tag verification in the read-only job
- reverify the signed tag in the narrowly scoped write job
- resolve exactly one reviewed draft there, where github exposes drafts

## why

github omits draft releases from a `contents: read` workflow token. release run 32666890970 failed closed before publication.

## verification

- write-job preflight found github-verified `v4.1.0` and draft release `375319184` without mutation
- `git diff --check`
- `bun run check`
- `bun run check:field-runs`

release remains draft.