### PR TITLE
refactor(site): centralize the publication type system

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check": "astro check",
     "check:field-runs": "node scripts/check-field-runs.mjs",
     "check:readme": "bun scripts/sync-readme.ts --check",
-    "test:site": "node scripts/test-site.mjs",
+    "test:site": "node scripts/check-typography.mjs && node scripts/test-site.mjs",
     "test:a11y": "node scripts/test-a11y.mjs",
     "preview": "astro preview",
     "sync:readme": "bun scripts/sync-readme.ts"

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -1,0 +1,40 @@
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const sourceRoot = path.join(root, 'src');
+const owner = path.join(sourceRoot, 'styles', 'typography.css');
+const controlledDeclaration = /(?:^|[;{])\s*(font|font-family|font-size|font-weight|line-height|letter-spacing|text-transform)\s*:/gm;
+const failures = [];
+
+const walk = async (directory) => {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return (await Promise.all(entries.map(async (entry) => {
+    const absolute = path.join(directory, entry.name);
+    return entry.isDirectory() ? walk(absolute) : [absolute];
+  }))).flat();
+};
+
+const lineFor = (source, offset) => source.slice(0, offset).split('\n').length;
+
+for (const file of await walk(sourceRoot)) {
+  if (file === owner || !/\.(?:astro|css)$/.test(file)) continue;
+  const source = await readFile(file, 'utf8');
+  const regions = file.endsWith('.astro')
+    ? [...source.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/g)].map((match) => ({ source: match[1], offset: match.index + match[0].indexOf(match[1]) }))
+    : [{ source, offset: 0 }];
+
+  for (const region of regions) {
+    for (const match of region.source.matchAll(controlledDeclaration)) {
+      failures.push(`${path.relative(root, file)}:${lineFor(source, region.offset + match.index)} declares ${match[1]} outside src/styles/typography.css`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log('validated centralized ownership of project typography declarations');

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -6,6 +6,7 @@ const root = process.cwd();
 const sourceRoot = path.join(root, 'src');
 const owner = path.join(sourceRoot, 'styles', 'typography.css');
 const controlledDeclaration = /(?:^|[;{])\s*(font|font-family|font-size|font-weight|line-height|letter-spacing|text-transform)\s*:/gm;
+const controlledInlineDeclaration = /\b(font|font-family|font-size|font-weight|line-height|letter-spacing|text-transform)\s*:/gm;
 const failures = [];
 
 const walk = async (directory) => {
@@ -22,11 +23,16 @@ for (const file of await walk(sourceRoot)) {
   if (file === owner || !/\.(?:astro|css)$/.test(file)) continue;
   const source = await readFile(file, 'utf8');
   const regions = file.endsWith('.astro')
-    ? [...source.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/g)].map((match) => ({ source: match[1], offset: match.index + match[0].indexOf(match[1]) }))
-    : [{ source, offset: 0 }];
+    ? [
+        ...[...source.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/g)]
+          .map((match) => ({ source: match[1], offset: match.index + match[0].indexOf(match[1]), matcher: controlledDeclaration })),
+        ...[...source.matchAll(/<[^>]*\bstyle\s*=[^>]*>/gs)]
+          .map((match) => ({ source: match[0], offset: match.index, matcher: controlledInlineDeclaration })),
+      ]
+    : [{ source, offset: 0, matcher: controlledDeclaration }];
 
   for (const region of regions) {
-    for (const match of region.source.matchAll(controlledDeclaration)) {
+    for (const match of region.source.matchAll(region.matcher)) {
       failures.push(`${path.relative(root, file)}:${lineFor(source, region.offset + match.index)} declares ${match[1]} outside src/styles/typography.css`);
     }
   }

--- a/scripts/test-a11y.mjs
+++ b/scripts/test-a11y.mjs
@@ -7,7 +7,9 @@ import { canonicalContentFiles } from '../src/content-manifest.mjs';
 const origin = 'http://127.0.0.1:4173';
 const routes = canonicalContentFiles().map((entry) => entry.route);
 const viewports = [
+  { name: 'reflow narrow', width: 320, height: 800 },
   { name: 'mobile small', width: 375, height: 812 },
+  { name: '200% browser zoom equivalent', width: 720, height: 500 },
   { name: 'mobile wide', width: 768, height: 1024 },
   { name: 'tablet square', width: 942, height: 942 },
   { name: 'desktop compact', width: 1024, height: 900 },
@@ -32,8 +34,100 @@ try {
     for (const route of routes) {
       await page.goto(`${origin}${route}`, { waitUntil: 'networkidle' });
       if (await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)) failures.push(`${viewport.name} ${route}: horizontal overflow`);
+      const typographyFailures = await page.evaluate(({ route, viewportWidth }) => {
+        const findings = [];
+        const ink = 'rgb(16, 17, 20)';
+        const slate = 'rgb(80, 87, 96)';
+        const close = (actual, expected, tolerance = 0.25) => Math.abs(actual - expected) <= tolerance;
+        const visible = (element) => element.getClientRects().length > 0 && getComputedStyle(element).visibility !== 'hidden';
+        const directText = (element) => [...element.childNodes].some((node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim());
+        const style = (element) => getComputedStyle(element);
+        const number = (value) => Number.parseFloat(value);
+        const checkRole = (elements, expected, label) => {
+          for (const element of elements.filter(visible)) {
+            const computed = style(element);
+            if (expected.size !== undefined && !close(number(computed.fontSize), expected.size)) findings.push(`${label} font-size ${computed.fontSize}: ${element.textContent.trim().slice(0, 60)}`);
+            if (expected.line !== undefined && !close(number(computed.lineHeight), expected.line)) findings.push(`${label} line-height ${computed.lineHeight}: ${element.textContent.trim().slice(0, 60)}`);
+            if (expected.weight !== undefined && computed.fontWeight !== String(expected.weight)) findings.push(`${label} font-weight ${computed.fontWeight}: ${element.textContent.trim().slice(0, 60)}`);
+            if (expected.family && !computed.fontFamily.includes(expected.family)) findings.push(`${label} font-family ${computed.fontFamily}: ${element.textContent.trim().slice(0, 60)}`);
+            if (expected.color && computed.color !== expected.color) findings.push(`${label} color ${computed.color}: ${element.textContent.trim().slice(0, 60)}`);
+          }
+        };
+        const elements = (selector) => [...document.querySelectorAll(selector)];
+
+        const textElements = elements('body *').filter((element) => visible(element) && directText(element));
+        for (const element of textElements) {
+          const computed = style(element);
+          if (number(computed.fontSize) < 12) findings.push(`public text below 12px (${computed.fontSize}): ${element.textContent.trim().slice(0, 60)}`);
+          if (computed.fontFamily.includes('Instrument Sans') && !['400', '600'].includes(computed.fontWeight)) findings.push(`unsupported sans weight ${computed.fontWeight}: ${element.textContent.trim().slice(0, 60)}`);
+        }
+
+        const displaySize = Math.min(64, Math.max(44, viewportWidth * .05));
+        const titleSize = Math.min(48, Math.max(36, viewportWidth * .04));
+        const headingSize = Math.min(32, Math.max(28, viewportWidth * .02));
+        if (route === '/') checkRole(elements('.home-content h1'), { size: displaySize, line: displaySize, weight: 600, family: 'Instrument Sans', color: ink }, 'display h1');
+        else checkRole(elements('main h1'), { size: titleSize, line: titleSize * 1.05, weight: 600, family: 'Instrument Sans', color: ink }, 'page h1');
+        if (route !== '/' && elements('.home-content h1').length > 0) findings.push('display h1 appears outside the homepage');
+        checkRole(elements('main h2'), { size: headingSize, line: headingSize * 1.15, weight: 600, family: 'Instrument Sans', color: ink }, 'content h2');
+        checkRole(elements('main h3'), { size: 22, line: 27.5, weight: 600, family: 'Instrument Sans', color: ink }, 'content h3');
+
+        const reading = elements('.home-content p, .home-guides p, .sl-markdown-content p, .run-page p, .page-sources > p:last-child')
+          .filter((element) => !element.matches('.section-label, .history-year, .run-header > p:first-child, .source-kinds, .page-meta'));
+        checkRole(reading, { size: 18, line: 30, weight: 400, family: 'Instrument Sans', color: ink }, 'reading prose');
+        for (const element of reading.filter(visible)) if (element.getBoundingClientRect().width > 816) findings.push(`reading measure exceeds 68ch: ${element.textContent.trim().slice(0, 60)}`);
+
+        checkRole(elements('td, .page-sources li, .run-inventory li, .artifact-list li, .run-page dd'), { size: 16, line: 24, weight: 400, family: 'Instrument Sans', color: ink }, 'dense content');
+        const metadata = elements('.github-stars, .section-label, .home-guide-list span, .home-meta, .sidebar-label, .page-meta, figcaption, .history-year, .run-header > p:first-child, .run-page dt, .run-evidence, .run-inventory span, .source-kinds, th');
+        checkRole(metadata, { size: 12, line: 18, weight: 400, family: 'IBM Plex Mono', color: slate }, 'metadata');
+        checkRole(elements('.site-name, .provider-tabs a, .handbook-sidebar a, .right-sidebar a, .right-sidebar h2, .site-footer a, .site-footer p'), { size: 14, line: 20, family: 'Instrument Sans' }, 'navigation');
+        return findings;
+      }, { route, viewportWidth: viewport.width });
+      for (const finding of typographyFailures) failures.push(`${viewport.name} ${route}: ${finding}`);
+
+      if (viewport.width === 375 && route === '/') {
+        const menu = page.locator('.mobile-site-menu summary');
+        const details = page.locator('.mobile-site-menu');
+        await menu.focus();
+        await page.keyboard.press('Enter');
+        if (await details.getAttribute('open') === null) failures.push(`${viewport.name} ${route}: mobile menu does not open with Enter`);
+        await page.keyboard.press('Enter');
+        if (await details.getAttribute('open') !== null) failures.push(`${viewport.name} ${route}: mobile menu does not close with Enter`);
+      }
+
       const report = await new AxeBuilder({ page }).analyze();
       for (const violation of report.violations.filter((item) => item.impact === 'serious' || item.impact === 'critical')) failures.push(`${viewport.name} ${route}: ${violation.impact} ${violation.id}`);
+
+      const checkClipping = async (label) => {
+        if (await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)) failures.push(`${viewport.name} ${route}: ${label} causes horizontal overflow`);
+        const clipped = await page.evaluate(() => {
+          const directText = (element) => [...element.childNodes].some((node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim());
+          return [...document.querySelectorAll('body *')]
+            .filter((element) => directText(element) && element.getClientRects().length > 0)
+            .filter((element) => {
+              const style = getComputedStyle(element);
+              const clippedInline = element.scrollWidth > element.clientWidth + 1 && ['clip', 'hidden'].includes(style.overflowX);
+              const clippedBlock = element.scrollHeight > element.clientHeight + 1 && ['clip', 'hidden'].includes(style.overflowY);
+              return clippedInline || clippedBlock;
+            })
+            .map((element) => element.textContent.trim().slice(0, 60));
+        });
+        for (const text of clipped) failures.push(`${viewport.name} ${route}: ${label} clips text: ${text}`);
+      };
+
+      if (viewport.width === 375) {
+        const spacing = await page.addStyleTag({ content: `
+          :where(p, li, dd, td, figcaption) {
+            line-height: 1.5 !important;
+            letter-spacing: .12em !important;
+            word-spacing: .16em !important;
+          }
+          p { margin-bottom: 2em !important; }
+        ` });
+        await checkClipping('text spacing override');
+        await spacing.evaluate((element) => element.remove());
+      }
+
+      if (viewport.width === 720) await checkClipping('200% browser zoom equivalent');
     }
     await context.close();
   }
@@ -44,4 +138,4 @@ try {
 }
 
 if (failures.length > 0) { console.error(failures.join('\n')); process.exit(1); }
-console.log(`axe found no serious or critical issues across ${routes.length} routes at ${viewports.length} required widths`);
+console.log(`typography, reflow, text spacing, text resize, and axe checks passed across ${routes.length} routes at ${viewports.length} required widths`);

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -26,7 +26,7 @@ const activeScopeLabel = navigationScopes.find((scope) => scope.id === activeSco
         <span class="github-stars" aria-hidden="true">{site.repositoryStars}</span>
       </a>
       <details class="mobile-site-menu">
-        <summary role="button" aria-label={site.interfaceCopy.menu} aria-controls="mobile-scope-menu">
+        <summary aria-label={site.interfaceCopy.menu} aria-controls="mobile-scope-menu">
           <Icon class="menu-open-icon" name="ph:list" aria-hidden="true" />
           <Icon class="menu-close-icon" name="ph:x" aria-hidden="true" />
         </summary>

--- a/src/components/StarlightFooter.astro
+++ b/src/components/StarlightFooter.astro
@@ -71,14 +71,11 @@ const runs = entry.id === 'method'
 </script>
 
 <style>
-  .run-inventory, .page-sources { margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--rule); }
-  .run-inventory h2, .page-sources h2 { font-size: clamp(1.8rem, 3vw, 2.7rem); }
+  .run-inventory, .page-sources { margin-top: 4rem; padding-top: 0; border-top: 1px solid var(--rule); }
   .run-inventory ul, .page-sources ul { margin: 0; padding: 0; border-top: 1px solid var(--ink); list-style: none; }
   .run-inventory li { display: grid; grid-template-columns: minmax(16rem, 1fr) auto auto; gap: 1rem; padding: 1rem 0; border-bottom: 1px solid var(--rule); }
   .page-sources li { padding: .8rem 0; border-bottom: 1px solid var(--rule); }
   .run-inventory a, .page-sources a { color: var(--cobalt); }
-  .run-inventory span, .source-kinds { color: var(--slate); font: .66rem var(--font-mono); text-transform: uppercase; }
-  .page-sources > p:last-child { color: var(--slate); }
   @media (max-width: 48rem) {
     .run-inventory li { grid-template-columns: 1fr; gap: .35rem; }
   }

--- a/src/components/StarlightSidebar.astro
+++ b/src/components/StarlightSidebar.astro
@@ -9,7 +9,7 @@ const label = navigationScopes.find((scope) => scope.id === activeScope)?.label 
 ---
 
 <nav class="handbook-sidebar" aria-label={`${label} navigation`}>
-  <h2>{label}</h2>
+  <p class="sidebar-label">{label}</p>
   <ul>
     {pages.map((page) => {
       const href = routeForEntry(page);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,4 @@
 ---
-import '@fontsource-variable/instrument-sans';
-import '@fontsource/ibm-plex-mono/400.css';
 import '../styles/global.css';
 import SiteHeader from '../components/SiteHeader.astro';
 import AccessibleTables from '../components/AccessibleTables.astro';

--- a/src/pages-dev/copy-review.astro
+++ b/src/pages-dev/copy-review.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, getEntry } from 'astro:content';
+import '../styles/global.css';
 import { getHandbookPages, routeForEntry } from '../content';
 import { evidenceLabels } from '../evidence';
 import { navigationScopes, site } from '../site';
@@ -32,29 +33,27 @@ const sharedCopy = [
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <title>local copy review</title>
     <style>
-      :root { font-family: ui-sans-serif, system-ui, sans-serif; color: #101114; background: #fff; }
+      :root { color: #101114; background: #fff; }
       * { box-sizing: border-box; }
       body { margin: 0; }
       header, main { width: min(100% - 2rem, 86rem); margin: 0 auto; }
       header { padding: 3rem 0 2rem; border-bottom: 1px solid #101114; }
-      h1 { margin: 0; font-size: clamp(2.5rem, 7vw, 6rem); letter-spacing: -.06em; }
-      header p { max-width: 48rem; color: #505760; line-height: 1.5; }
+      h1 { margin: 0; }
+      header p { max-width: 48rem; }
       section { padding: 2.5rem 0; border-bottom: 1px solid #c9cdd3; }
-      h2 { font-size: clamp(1.7rem, 3vw, 2.6rem); letter-spacing: -.04em; }
       .tree, .shared, .surfaces { margin: 0; padding: 0; list-style: none; }
       .tree li, .shared li { display: grid; grid-template-columns: minmax(12rem, .6fr) 1.4fr; gap: 1rem; padding: .7rem 0; border-top: 1px solid #e5e7ea; }
       .surface { margin: 0 0 2rem; border: 1px solid #c9cdd3; }
       .surface > header { width: auto; padding: 1.2rem; border-bottom: 1px solid #c9cdd3; }
-      .surface h3 { margin: 0 0 .35rem; font-size: 1.35rem; }
+      .surface h3 { margin: 0 0 .35rem; }
       .surface header p { margin: .25rem 0; }
-      .owner, .voice { color: #505760; font: .72rem ui-monospace, monospace; }
       .copy { margin: 0; padding: 0 1.2rem 1.2rem; list-style: none; }
-      .copy li { display: grid; grid-template-columns: 5rem 1fr; gap: 1rem; padding: .7rem 0; border-bottom: 1px solid #e5e7ea; line-height: 1.45; }
+      .copy li { display: grid; grid-template-columns: 5rem 1fr; gap: 1rem; padding: .7rem 0; border-bottom: 1px solid #e5e7ea; }
       a { color: #1247e6; }
       @media (max-width: 42rem) { .tree li, .shared li, .copy li { grid-template-columns: 1fr; gap: .3rem; } }
     </style>
   </head>
-  <body>
+  <body class="copy-review-page">
     <header>
       <p>development only</p>
       <h1>local copy review</h1>

--- a/src/pages/field-lab/runs/[runId].astro
+++ b/src/pages/field-lab/runs/[runId].astro
@@ -78,26 +78,22 @@ const date = data.date.toISOString().slice(0, 10);
 
 <style>
   .run-page { max-width: 76rem; margin: 0 auto; padding: 5rem clamp(1.25rem, 6vw, 5rem); }
-  .run-header > p:first-child { margin: 0 0 1rem; color: var(--cobalt); font: .66rem var(--font-mono); text-transform: uppercase; letter-spacing: .09em; }
-  .run-header h1 { max-width: 58rem; margin: 0; font-size: clamp(2.6rem, 6vw, 5.4rem); line-height: .96; letter-spacing: -.055em; overflow-wrap: anywhere; }
-  .run-description { max-width: 46rem; color: var(--slate); font-size: 1.15rem; line-height: 1.5; }
+  .run-header > p:first-child { margin: 0 0 1rem; }
+  .run-header h1 { max-width: 58rem; margin: 0; overflow-wrap: anywhere; }
+  .run-description { max-width: 68ch; margin: 1.5rem 0 0; }
   .run-header dl, .run-task dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 3rem 0 5rem; border-top: 1px solid var(--ink); }
   .run-header dl div, .run-task dl div, .compact-data div { padding: 1.1rem 1rem 1.1rem 0; border-bottom: 1px solid var(--rule); }
-  dt { color: var(--slate); font: .61rem var(--font-mono); text-transform: uppercase; letter-spacing: .06em; }
   dd { margin: .45rem 0 0; overflow-wrap: anywhere; }
-  .run-page h2 { margin-top: 4.5rem; font-size: clamp(1.8rem, 3.5vw, 3rem); letter-spacing: -.045em; }
   .run-body :global(table) { width: 100%; }
   .artifact-list { margin: 0; padding: 0; border-top: 1px solid var(--ink); list-style: none; }
   .artifact-list li { display: grid; grid-template-columns: minmax(9rem, 1fr) 2fr; gap: 2rem; padding: 1.1rem 0; border-bottom: 1px solid var(--rule); }
   .artifact-list a { color: var(--cobalt); }
-  .artifact-list span { color: var(--slate); }
   .run-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6vw; }
-  .run-grid ul, .run-page section > ul { padding-left: 1.2rem; color: var(--slate); line-height: 1.6; }
+  .run-grid ul, .run-page section > ul { padding-left: 1.2rem; }
   .compact-data { margin: 0; }
-  .run-evidence { display: flex; flex-wrap: wrap; gap: .6rem; margin-top: 4rem; padding-top: 1rem; border-top: 1px solid var(--ink); color: var(--cobalt); font: .65rem var(--font-mono); text-transform: uppercase; }
+  .run-evidence { display: flex; flex-wrap: wrap; gap: .6rem; margin-top: 4rem; padding-top: 1rem; border-top: 1px solid var(--ink); }
   @media (max-width: 48rem) {
     .run-page { padding-top: 3.5rem; }
-    .run-header h1 { font-size: clamp(2.4rem, 12vw, 3.2rem); }
     .run-header dl, .run-task dl, .run-grid { grid-template-columns: 1fr; }
     .artifact-list li { grid-template-columns: 1fr; gap: .4rem; }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,4 @@
-@import '@fontsource-variable/instrument-sans';
-@import '@fontsource/ibm-plex-mono/400.css';
+@import './typography.css';
 
 :root {
   --white: #ffffff;
@@ -12,10 +11,6 @@
   --radius-ui: .25rem;
   --site-header-height: 6.65rem;
   --site-gutter: clamp(1rem, 2vw, 1.5rem);
-  --font-sans: 'Instrument Sans Variable', 'Instrument Sans', sans-serif;
-  --font-mono: 'IBM Plex Mono', monospace;
-  --sl-font: var(--font-sans);
-  --sl-font-mono: var(--font-mono);
   --sl-color-accent-low: #e9efff;
   --sl-color-accent: var(--cobalt);
   --sl-color-accent-high: #0a2c91;
@@ -39,13 +34,11 @@
   --sl-content-width: 48rem;
   --sl-content-pad-x: 1rem;
   color-scheme: light;
-  font-family: var(--font-sans);
-  font-synthesis: none;
 }
 
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; background: var(--white); color: var(--ink); }
-body { margin: 0; background: var(--white); color: var(--ink); font-family: var(--font-sans); }
+body { margin: 0; background: var(--white); color: var(--ink); }
 a { color: inherit; }
 a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px solid var(--cobalt); outline-offset: 3px; }
 .skip-link { position: fixed; inset: 0 auto auto 0; z-index: 100; padding: .65rem 1rem; background: var(--ink); color: var(--white); transform: translateY(-120%); }
@@ -53,11 +46,11 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 
 .site-header { position: relative; z-index: 50; min-height: var(--site-header-height); border-bottom: 1px solid var(--rule); display: grid; grid-template-rows: 3.9rem 2.75rem; background: var(--white); }
 .header-main { padding: 0 var(--site-gutter); display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
-.site-name { display: inline-flex; align-items: center; gap: .7rem; width: max-content; text-decoration: none; font-weight: 700; letter-spacing: -.015em; }
+.site-name { display: inline-flex; align-items: center; gap: .7rem; width: max-content; text-decoration: none; }
 .site-name img { inline-size: 1.5rem; block-size: 1.5rem; flex: none; border-radius: var(--radius-ui); }
 .provider-tabs { min-inline-size: 0; padding: 0 var(--site-gutter); border-top: 1px solid var(--rule); display: flex; align-items: end; justify-content: center; gap: clamp(1.5rem, 4vw, 3.5rem); overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: none; }
 .provider-tabs::-webkit-scrollbar { display: none; }
-.provider-tabs a { position: relative; padding: .78rem .05rem .66rem; color: var(--slate); text-decoration: none; white-space: nowrap; font-size: .86rem; }
+.provider-tabs a { position: relative; padding: .78rem .05rem .66rem; color: var(--slate); text-decoration: none; white-space: nowrap; }
 .provider-tabs a::after { content: ''; position: absolute; inset: auto 0 0; block-size: 2px; background: transparent; }
 .provider-tabs a:hover, .provider-tabs a[aria-current='page'] { color: var(--ink); }
 .provider-tabs a[aria-current='page']::after { background: var(--cobalt); }
@@ -65,35 +58,30 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .github-link { display: inline-flex; align-items: center; gap: .4rem; justify-self: end; color: var(--ink); }
 .github-link { text-decoration: none; }
 .github-link svg { inline-size: 1.35rem; block-size: 1.35rem; }
-.github-stars { font: .68rem var(--font-mono); }
 .mobile-site-menu { display: none; }
 
 .home-content, .home-guides, .home-meta { width: min(100% - 2rem, 76rem); margin-inline: auto; }
 .home-content { padding: clamp(3.5rem, 8vw, 7rem) 0 5rem; }
-.home-content h1 { max-width: 68rem; margin: 0; font-size: clamp(3rem, 7vw, 6.8rem); font-weight: 560; letter-spacing: -.065em; line-height: .92; text-wrap: balance; }
+.home-content h1 { max-width: 68rem; text-wrap: balance; }
 .keyword-highlight { padding: .01em .1em .07em; border-radius: var(--radius-ui); background: var(--cobalt); color: var(--white); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
 .home-content h1 .keyword-highlight { white-space: nowrap; }
-.home-content > p:first-of-type { max-width: 45rem; margin: 2rem 0 5rem; color: var(--slate); font-size: clamp(1.05rem, 1.6vw, 1.3rem); line-height: 1.55; }
-.home-content h2, .home-guides h2 { margin: 4rem 0 1rem; font-size: clamp(2rem, 4vw, 3.7rem); line-height: 1; letter-spacing: -.05em; }
-.home-content h2 + p { max-width: 44rem; color: var(--slate); font-size: 1.1rem; line-height: 1.55; }
-.home-content table { width: 100%; margin-top: 2.5rem; border-collapse: collapse; font-size: .94rem; }
-.home-content th { padding: .75rem; border-top: 1px solid var(--ink); border-bottom: 1px solid var(--rule); color: var(--slate); font: .62rem var(--font-mono); text-align: left; text-transform: uppercase; }
-.home-content td { padding: 1rem .75rem; border-bottom: 1px solid var(--rule); vertical-align: top; }
+.home-content > p:first-of-type { max-width: 68ch; }
+.home-content h2 + p { max-width: 68ch; }
+.home-content table { width: 100%; margin-top: 1.5rem; border-collapse: collapse; }
+.home-content th { padding: .75rem 1rem; border-top: 1px solid var(--ink); border-bottom: 1px solid var(--rule); text-align: left; }
+.home-content td { padding: .75rem 1rem; border-bottom: 1px solid var(--rule); vertical-align: top; }
 .home-guides { padding: 1rem 0 5rem; }
 .home-guides-heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, 34rem); gap: 1rem 3rem; align-items: end; margin: 4rem 0 1.5rem; }
-.home-guides-heading .section-label { grid-column: 1 / -1; margin: 0; color: var(--cobalt); font: .65rem var(--font-mono); text-transform: uppercase; letter-spacing: .07em; }
+.home-guides-heading .section-label { grid-column: 1 / -1; margin: 0; }
 .home-guides-heading h2 { margin: 0; }
-.home-guides-heading > p:last-child { max-width: 34rem; margin: 0 0 .2rem; color: var(--slate); font-size: 1.05rem; line-height: 1.5; }
+.home-guides-heading > p:last-child { max-width: 34rem; margin: 0 0 .2rem; }
 .home-guide-list { border-top: 1px solid var(--ink); }
 .home-guide-list a { display: grid; grid-template-columns: 1fr 1.5fr 1fr 1.5rem; align-items: start; gap: 1.5rem; padding: 1.25rem 0; border-bottom: 1px solid var(--rule); text-decoration: none; }
 .home-guide-list h3, .home-guide-list p { margin: 0; }
-.home-guide-list h3 { font-size: 1.3rem; }
-.home-guide-list p { color: var(--slate); line-height: 1.45; }
-.home-guide-list span { color: var(--cobalt); font: .61rem/1.5 var(--font-mono); text-transform: uppercase; }
 .home-guide-list svg { inline-size: 1rem; color: var(--cobalt); }
 .home-guide-list a:hover h3 { color: var(--cobalt); }
-.home-meta { display: flex; gap: 1.5rem; padding: 1rem 0 3rem; border-top: 1px solid var(--ink); color: var(--slate); font: .62rem var(--font-mono); text-transform: uppercase; }
-.site-footer { min-height: 9rem; padding: 2.5rem clamp(1.25rem, 7vw, 8rem); display: grid; grid-template-columns: 1fr auto; gap: 2rem; align-items: start; border-top: 1px solid var(--ink); font: .68rem var(--font-mono); text-transform: uppercase; letter-spacing: .06em; }
+.home-meta { display: flex; gap: 1.5rem; padding: 1rem 0 3rem; border-top: 1px solid var(--ink); }
+.site-footer { min-height: 9rem; padding: 2.5rem clamp(1.25rem, 7vw, 8rem); display: grid; grid-template-columns: 1fr auto; gap: 2rem; align-items: start; border-top: 1px solid var(--ink); }
 .site-footer p { margin: 0; }
 .site-footer nav { display: flex; gap: 2rem; }
 .footer-github svg { inline-size: 1.15rem; block-size: 1.15rem; }
@@ -101,51 +89,46 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 /* Starlight publication shell */
 header.header { height: var(--site-header-height); padding: 0 !important; border-bottom: 1px solid var(--rule); box-shadow: none; }
 .sidebar-pane { border-inline-end: 1px solid var(--rule); }
-.sidebar-content { font-size: .86rem; }
 .handbook-sidebar { padding: 1.2rem 1rem; }
-.handbook-sidebar h2 { margin: 0 0 .65rem; color: var(--slate); font: .65rem var(--font-mono); text-transform: uppercase; letter-spacing: .07em; }
+.handbook-sidebar .sidebar-label { margin: 0 0 .65rem; }
 .handbook-sidebar ul { margin: 0; padding: 0; list-style: none; }
 .handbook-sidebar li + li { margin-top: .15rem; }
-.handbook-sidebar a { display: block; padding: .58rem .7rem; border-radius: var(--radius-ui); color: var(--slate); text-decoration: none; line-height: 1.35; }
+.handbook-sidebar a { display: block; padding: .58rem .7rem; border-radius: var(--radius-ui); color: var(--slate); text-decoration: none; }
 .handbook-sidebar a:hover { background: var(--soft); color: var(--ink); }
-.handbook-sidebar a[aria-current='page'] { background: var(--cobalt); color: var(--white); font-weight: 650; }
+.handbook-sidebar a[aria-current='page'] { background: var(--cobalt); color: var(--white); }
 .handbook-sidebar a[aria-current='page']:hover { background: #0c37ba; color: var(--white); }
 .content-panel { border-top: 0 !important; }
-.sl-markdown-content { color: var(--ink); font-size: 1.04rem; line-height: 1.68; }
-.sl-markdown-content h2, .sl-markdown-content h3 { color: var(--ink); letter-spacing: -.035em; }
-.sl-markdown-content h2 { margin-top: 3.8rem; padding-top: 1.25rem; border-top: 1px solid var(--rule); font-size: 2rem; }
-.sl-markdown-content > h2:first-child { margin-top: 0; padding-top: 0; border-top: 0; }
-.sl-markdown-content > h2:first-of-type:not(:first-child) { margin-top: 2rem; padding-top: 0; border-top: 0; }
-.sl-markdown-content h3 { font-size: 1.35rem; }
+.sl-markdown-content { color: var(--ink); }
 .sl-markdown-content a { color: var(--cobalt); text-underline-offset: .2rem; }
-.sl-markdown-content table { display: table; inline-size: 100%; border-radius: var(--radius-ui); overflow: clip; font-size: .9rem; }
-.sl-markdown-content th { background: var(--soft); font: .65rem var(--font-mono); text-transform: uppercase; letter-spacing: .05em; }
+.sl-markdown-content table { display: table; inline-size: 100%; margin-top: 1.5rem; border-radius: var(--radius-ui); overflow: clip; }
+.sl-markdown-content th { background: var(--soft); }
+.sl-markdown-content th, .sl-markdown-content td { padding: .75rem 1rem; }
 .sl-markdown-content th, .sl-markdown-content td { border-color: var(--rule); }
 .sl-markdown-content code { border-radius: var(--radius-ui); background: var(--soft); color: var(--ink); }
 .sl-markdown-content pre { border-radius: var(--radius-ui); background: var(--ink) !important; }
 .sl-markdown-content pre code { background: transparent; color: #f5f7fb; }
 .sl-markdown-content pre code span { color: var(--shiki-light, #f5f7fb) !important; }
-#_top { margin: 0; color: var(--ink); font-size: clamp(2.8rem, 5vw, 4.7rem); font-weight: 560; line-height: .95; letter-spacing: -.055em; }
-.page-meta { margin: 1.15rem 0 0; color: var(--slate); font: .65rem var(--font-mono); text-transform: uppercase; letter-spacing: .055em; }
+#_top { margin: 0; color: var(--ink); }
+.page-meta { margin: 1.125rem 0 0; }
 .right-sidebar { background: var(--soft); }
-.right-sidebar a[aria-current='true'] { color: var(--cobalt); font-weight: 650; }
+.right-sidebar a[aria-current='true'] { color: var(--cobalt); }
 .right-sidebar a[aria-current='true']::before { background: var(--cobalt); }
 
 .surface-bento { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin: 1.75rem 0 2.5rem; }
 .surface-bento figure { min-width: 0; margin: 0; border: 1px solid var(--rule); border-radius: var(--radius-ui); overflow: hidden; background: var(--soft); }
 .surface-bento a { display: block; text-decoration: none; }
 .surface-bento img { display: block; inline-size: 100%; aspect-ratio: 16 / 9; object-fit: cover; background: var(--soft); }
-.surface-bento figcaption { padding: .8rem .9rem; color: var(--slate); font: .66rem/1.45 var(--font-mono); text-transform: uppercase; }
+.surface-bento figcaption { padding: .8rem .9rem; }
 
 .history-timeline { margin: 3rem 0 0; padding: 0; border-top: 1px solid var(--ink); list-style: none; }
 .history-timeline > li { display: grid; grid-template-columns: 7.5rem minmax(0, 1fr); gap: .7rem 2rem; padding: 2.25rem 0 2.5rem; border-bottom: 1px solid var(--rule); }
-.history-timeline .history-year { grid-row: 1 / span 3; margin: .35rem 0 0; color: var(--cobalt); font: .7rem/1.4 var(--font-mono); text-transform: uppercase; letter-spacing: .06em; }
-.history-timeline h2 { grid-column: 2; margin: 0; padding: 0; border: 0; font-size: clamp(1.65rem, 3vw, 2.35rem); }
+.history-timeline .history-year { grid-row: 1 / span 3; margin: .35rem 0 0; }
+.history-timeline h2 { grid-column: 2; margin: 0; padding: 0; border: 0; }
 .history-timeline li > p:not(.history-year) { grid-column: 2; max-width: 42rem; margin: .35rem 0 0; }
 .history-timeline cite { font-style: normal; }
 .history-timeline figure { grid-column: 2; max-width: 42rem; margin: 1rem 0 0; border-radius: var(--radius-ui); overflow: hidden; background: var(--soft); }
 .history-timeline figure img { display: block; inline-size: 100%; max-block-size: 20rem; object-fit: cover; }
-.history-timeline figcaption { padding: .6rem .75rem; color: var(--slate); font: .62rem/1.45 var(--font-mono); text-transform: uppercase; }
+.history-timeline figcaption { padding: .6rem .75rem; }
 
 @media (max-width: 64rem) {
   .home-guide-list a { grid-template-columns: 1fr 1.5fr 1.5rem; }
@@ -183,13 +166,10 @@ header.header { height: var(--site-header-height); padding: 0 !important; border
   html { scroll-behavior: auto; }
   .site-header { min-height: var(--site-header-height); }
   .provider-tabs { justify-content: flex-start; }
-  .site-name { font-size: .9rem; }
   .home-content { padding-top: 3.5rem; }
-  .home-content h1 { font-size: clamp(2.75rem, 12vw, 4rem); }
-  .home-content > p:first-of-type { margin-bottom: 3.5rem; }
   .home-guides-heading { grid-template-columns: 1fr; margin-top: 2.5rem; }
   .home-guides-heading .section-label { grid-column: 1; }
-  .home-content table { display: block; overflow-x: auto; font-size: .9rem; }
+  .home-content table { display: block; overflow-x: auto; }
   .home-content th, .home-content td { min-width: 9.5rem; }
   .home-guide-list a { grid-template-columns: 1fr 1.5rem; gap: .6rem; }
   .home-guide-list h3, .home-guide-list p, .home-guide-list span { grid-column: 1; }
@@ -198,6 +178,7 @@ header.header { height: var(--site-header-height); padding: 0 !important; border
   .site-footer { grid-template-columns: 1fr; min-height: 0; }
   .site-footer nav { flex-wrap: wrap; }
   .sl-markdown-content table { display: block; overflow-x: auto; }
+  .run-body table { display: block; max-inline-size: 100%; overflow-x: auto; }
   .surface-bento { grid-template-columns: 1fr; }
   .history-timeline > li { grid-template-columns: 1fr; gap: .65rem; }
   .history-timeline .history-year, .history-timeline h2, .history-timeline li > p:not(.history-year), .history-timeline figure { grid-column: 1; grid-row: auto; }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,221 @@
+@import '@fontsource-variable/instrument-sans';
+@import '@fontsource/ibm-plex-mono/400.css';
+
+:root {
+  --font-sans: 'Instrument Sans Variable', 'Instrument Sans', sans-serif;
+  --font-mono: 'IBM Plex Mono', monospace;
+  --type-display-size: clamp(2.75rem, 5vw, 4rem);
+  --type-title-size: clamp(2.25rem, 4vw, 3rem);
+  --type-heading-size: clamp(1.75rem, 2vw, 2rem);
+  --type-subheading-size: 1.375rem;
+  --type-body-size: 1.125rem;
+  --type-dense-size: 1rem;
+  --type-navigation-size: .875rem;
+  --type-metadata-size: .75rem;
+  --type-body-line: 1.875rem;
+  --type-dense-line: 1.5rem;
+  --type-navigation-line: 1.25rem;
+  --type-metadata-line: 1.125rem;
+  --sl-font: var(--font-sans);
+  --sl-font-mono: var(--font-mono);
+  --sl-text-xs: var(--type-metadata-size);
+  --sl-text-sm: var(--type-navigation-size);
+  --sl-text-base: var(--type-dense-size);
+  --sl-text-lg: var(--type-body-size);
+  --sl-text-xl: var(--type-subheading-size);
+  --sl-text-2xl: 1.75rem;
+  --sl-text-3xl: 2rem;
+  --sl-text-4xl: 3rem;
+  --sl-text-5xl: 4rem;
+  font-family: var(--font-sans);
+  font-synthesis: none;
+}
+
+body {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-body-size);
+  font-weight: 400;
+  line-height: var(--type-body-line);
+}
+
+:where(button, input, select, summary, textarea) { font: inherit; }
+:where(strong, b) { font-weight: 600; }
+
+:where(main, .run-inventory, .page-sources) h1 {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-title-size);
+  font-weight: 600;
+  letter-spacing: -.03em;
+  line-height: 1.05;
+}
+
+.home-content h1 {
+  font-size: var(--type-display-size);
+  letter-spacing: -.035em;
+  line-height: 1;
+}
+
+:where(main, .run-inventory, .page-sources) h2 {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-heading-size);
+  font-weight: 600;
+  letter-spacing: -.025em;
+  line-height: 1.15;
+}
+
+:where(main, .run-inventory, .page-sources) h3 {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-subheading-size);
+  font-weight: 600;
+  letter-spacing: -.015em;
+  line-height: 1.25;
+}
+
+:where(main, .run-inventory, .page-sources) h4 {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-body-size);
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.4;
+}
+
+.home-content h1 { margin-block: 0 1.5rem; }
+.home-content > p:first-of-type { margin-block: 0; }
+.home-content h2 { margin-block: 3rem 1rem; }
+.home-guides h2 { margin-block: 0; }
+.home-guide-list h3, .home-guide-list p { margin: 0; }
+
+.sl-markdown-content h2, .run-page h2, .run-inventory h2, .page-sources h2, .copy-review-page main h2 {
+  margin-block: 3rem 1rem;
+}
+
+.sl-markdown-content h2 {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.sl-markdown-content > h2:first-child { margin-top: 0; }
+.sl-markdown-content h3, .run-page h3, .copy-review-page main h3 { margin-block: 2rem .75rem; }
+.sl-markdown-content h4, .run-page h4, .copy-review-page main h4 { margin-block: 1.5rem .5rem; }
+
+.home-content :where(p, ul, ol),
+.home-guides :where(p, ul, ol),
+.sl-markdown-content :where(p, ul, ol),
+.run-page :where(p, ul, ol),
+.copy-review-page main :where(p, ul, ol) {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-body-size);
+  font-weight: 400;
+  line-height: var(--type-body-line);
+  margin-block: 0;
+}
+
+.home-content :where(p, ul, ol), .sl-markdown-content :where(p, ul, ol), .run-page :where(p, ul, ol) { max-width: 68ch; }
+.page-sources > p:last-child { max-width: 68ch; }
+.home-content :where(p, ul, ol) + :where(p, ul, ol),
+.sl-markdown-content :where(p, ul, ol) + :where(p, ul, ol),
+.run-page :where(p, ul, ol) + :where(p, ul, ol) { margin-top: 1.125rem; }
+
+.home-content h2 + p, .home-guides-heading > p:last-child, .home-guide-list p, .run-description,
+.artifact-list span, .run-grid ul, .run-page section > ul, .page-sources > p:last-child {
+  color: var(--ink);
+}
+
+:where(.home-content, .sl-markdown-content, .run-body) table,
+:where(.home-content, .sl-markdown-content, .run-body) td,
+.run-page dd,
+.artifact-list,
+.run-inventory li,
+.page-sources li {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: var(--type-dense-size);
+  font-weight: 400;
+  line-height: var(--type-dense-line);
+}
+
+.site-name, .provider-tabs a, .handbook-sidebar a, .right-sidebar a,
+.right-sidebar h2, .site-footer a, .site-footer p {
+  font-family: var(--font-sans);
+  font-size: var(--type-navigation-size);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: var(--type-navigation-line);
+  text-transform: none;
+}
+
+.site-name, .provider-tabs a[aria-current='page'], .handbook-sidebar a[aria-current='page'],
+.right-sidebar a[aria-current='true'] { font-weight: 600; }
+
+.mobile-site-menu nav a {
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+}
+
+.mobile-site-menu nav a[aria-current='page'] { font-weight: 600; }
+
+.github-stars, .section-label, .home-guide-list span, .home-meta,
+.sidebar-label, .page-meta, .surface-bento figcaption, .history-year,
+.history-timeline figcaption, .run-header > p:first-child, .run-page dt,
+.run-evidence, .run-inventory span, .source-kinds,
+.copy-review-page .owner, .copy-review-page .voice,
+.copy-review-page .copy li > span:first-child,
+:where(.home-content, .sl-markdown-content, .run-body) th {
+  font-family: var(--font-mono);
+  font-size: var(--type-metadata-size);
+  font-weight: 400;
+  letter-spacing: .04em;
+  line-height: var(--type-metadata-line);
+}
+
+.github-stars, .sidebar-label, .page-meta, .surface-bento figcaption,
+.history-timeline figcaption, .run-inventory span, .source-kinds,
+.copy-review-page .owner, .copy-review-page .voice,
+.copy-review-page .copy li > span:first-child,
+:where(.home-content, .sl-markdown-content, .run-body) th { color: var(--slate); }
+
+.section-label, .home-guide-list span, .home-meta, .history-year,
+.run-header > p:first-child, .run-page dt, .run-evidence { color: var(--slate); }
+
+.section-label, .home-guide-list span, .home-meta, .sidebar-label, .page-meta,
+.surface-bento figcaption, .history-year, .history-timeline figcaption,
+.run-header > p:first-child, .run-page dt, .run-evidence, .run-inventory span,
+.source-kinds, .copy-review-page .owner, .copy-review-page .voice,
+.copy-review-page .copy li > span:first-child { max-width: none; }
+
+.section-label, .home-guide-list span, .home-meta, .sidebar-label, .page-meta,
+.history-year, .run-header > p:first-child, .run-page dt, .run-evidence,
+.run-inventory span, .source-kinds,
+:where(.home-content, .sl-markdown-content, .run-body) th { text-transform: uppercase; }
+
+.surface-bento figcaption, .history-timeline figcaption,
+.copy-review-page .owner, .copy-review-page .voice,
+.copy-review-page .copy li > span:first-child { text-transform: none; }
+
+:where(.home-content, .sl-markdown-content, .run-page, .copy-review-page) :not(pre) > code {
+  font-family: var(--font-mono);
+  font-size: var(--type-dense-size);
+  font-weight: 400;
+  line-height: var(--type-dense-line);
+}
+
+:where(.home-content, .sl-markdown-content, .run-page, .copy-review-page) pre,
+:where(.home-content, .sl-markdown-content, .run-page, .copy-review-page) pre code,
+:where(.home-content, .sl-markdown-content, .run-page, .copy-review-page) pre code span {
+  font-family: var(--font-mono);
+  font-size: var(--type-navigation-size);
+  font-weight: 400;
+  line-height: 1.375rem;
+}
+
+.copy-review-page header p { line-height: var(--type-body-line); }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -27,6 +27,7 @@
   --sl-text-3xl: 2rem;
   --sl-text-4xl: 3rem;
   --sl-text-5xl: 4rem;
+
   font-family: var(--font-sans);
   font-synthesis: none;
 }
@@ -42,7 +43,8 @@ body {
 :where(button, input, select, summary, textarea) { font: inherit; }
 :where(strong, b) { font-weight: 600; }
 
-:where(main, .run-inventory, .page-sources) h1 {
+:where(main, .run-inventory, .page-sources) h1,
+.copy-review-page > header h1 {
   color: var(--ink);
   font-family: var(--font-sans);
   font-size: var(--type-title-size);


### PR DESCRIPTION
## summary

- centralize every project-owned typography declaration in `src/styles/typography.css`
- replace page-specific title, heading, prose, metadata, table, navigation, and field-run treatments with one shared role system
- enforce typography ownership in CSS, Astro style blocks, and Astro inline style attributes
- preserve routes, copy, media, navigation structure, and the November 5, 2026 compatibility promise

## rationale

The rendered publication had overlapping global, Starlight, page, and component typography rules. The result was 65 desktop and 59 mobile composite typography variants, inconsistent reading measures, several paragraph sizes, tiny metadata, and page-specific title systems. One owner and a small named role set remove the source of those deviations and make later exceptions visible in review.

## evidence

### primary sources

- the project design direction and compatibility boundary in `AGENTS.md`
- WCAG 2.2 resize text, reflow, text spacing, and contrast criteria encoded in the rendered checks

### tested artifacts

- all 17 canonical routes at 320, 375, 720, 768, 942, 1024, 1191, and 1440 CSS pixels
- representative homepage, guide, history, and field-run screenshots kept outside the repository
- desktop census: 30 to 8 font sizes; 65 to 22 composite variants
- mobile census: 25 to 8 font sizes; 59 to 19 composite variants
- minimum rendered size: 12px; rendered project sans weights: 400 and 600
- temporary inline `font-size` fixture was rejected by the ownership guard at its exact source line, then removed

### verification checklist

- `bun run check:field-runs`
- `bun run check:readme`
- `bun run check` (0 errors, warnings, or hints)
- `bun run build`
- `bun run test:site`
- `bun run test:a11y` (17 routes at 8 widths, including 320px reflow, text-spacing overrides, zoom-equivalent reflow, clipping, keyboard menu, and axe)
- `python3 .github/scripts/check_sources.py`
- tracked JSON, Python, and shell validation
- `bun test plugins/cc/tests` (45 passed)
- `pytest plugins/lore/tests` (175 passed)

### inferences and unknowns

- the reduced census and rendered regression matrix support a materially simpler and more consistent system; human preference about the final scale remains reviewable in the local preview
- production appearance is not claimed until the merged Pages deployment is separately verified

### field-run impact

- no field-run content, evidence, route, or schema changes
- field-run tables retain their wider container and gain bounded horizontal scrolling on narrow viewports

## boundary

This PR changes project-owned typography styling, semantic markup for the development copy-review/sidebar labels, the mobile table container, and associated verification only. It does not change public copy, content schemas, routes, provider settings, releases, archive contents, or the compatibility date. Legacy compatibility remains preserved through November 5, 2026. Merge activates the typography contract and may trigger the repository's normal Pages deployment; releases and provider-surface changes remain separate actions.
