### PR TITLE
refactor(site): simplify the homepage index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ this repository is an opinionated, source backed handbook for experienced coding
 - prefer primary sources and record them in `docs/sources.json`.
 - do not use generated activity, commit frequency, or vendor benchmarks as evidence of quality.
 - keep the voice direct, lowercase, and professional. avoid hype, fan language, and unsupported authority claims.
+- treat Ani's submitted wording and manual browser edits as the primary voice reference. preserve his phrasing unless accuracy, safety, or clarity requires a change, and explain that conflict instead of silently polishing it away.
+- write like a personal, engaging handbook built from curiosity and use: concrete experiences, recognizable details, honest uncertainty, and a clear reason for caring. avoid generic authority language and an overly technical textbook voice.
 - do not use mid-dot dividers in public copy or interface labels.
 - never use litotes or negative comparison frames in public copy. state the intended claim directly.
 - repeat context only when it changes understanding or supports a deliberate editorial rhythm. remove labels that restate the title, route, or surrounding section.

--- a/content/home.md
+++ b/content/home.md
@@ -1,8 +1,8 @@
 ---
 title: coding agent tips
-description: practical guidance for choosing, operating, and reviewing coding agents when the work has real users, real constraints, and consequences.
+description: practical guidance for operating coding agents under constraints and tradeoffs of the real world.
 products: [cross runtime]
-updatedAt: "2026-08-22T19:55:02-04:00"
+updatedAt: "2026-08-27T01:36:11-04:00"
 status: current
 evidence: [tested, official-source, analysis]
 sources: []
@@ -16,43 +16,24 @@ navigation:
 
 # a guide to <mark class="keyword-highlight">coding agents</mark> in production software (projects, startups & big tech)
 
-practical guidance for choosing, operating, and reviewing coding agents when the
-work has real users, real constraints, and consequences.
+practical guidance for operating coding agents under constraints and tradeoffs
+of the real world.
 
-## why i keep this guide
+## why i made this
 
-i spend an unreasonable amount of time using coding agents, figuring out where
-they actually help, recovering when they get something wrong, and documenting
-the patterns that survive more than one task.
+over the last two years, i’ve spent a pretty unreasonable amount of time trying
+to understand coding with AI.
 
-agents already handle meaningful parts of my work. they also lose context,
-misunderstand scope, produce plausible mistakes, and need supervision when the
-stakes rise. nobody knows the date or slope of the next capability jump. that
-uncertainty makes it worth understanding which parts of your work or life benefit
-now, where your judgment carries the load, how permissions change the risk, and
-which workflows remain reliable.
+that started with using them to build things for myself, mostly because i was
+curious and wanted to learn faster. then i started using them for my own
+business, for work with record labels, and eventually on software being used by
+YC-backed companies. somewhere along the way, i also became the kind of person
+who checks x every other week to see which model suddenly got better, what
+changed in codex or claude code, which tiny startup just got acquihired for $10B,
+and who the next freakishly smart 24yo everyone is arguing about will be.
 
-the credibility here comes from the work itself. i link the [repository](https://github.com/anipotts/coding-agent-tips),
-[field runs](/method/#field-runs), [recorded failures](/field-lab/runs/codex-dependency-maintenance-2026-08-11/),
-code, and other artifacts behind the tips. you can inspect the receipts and
-decide what transfers to your own work.
+i also became interested in the bigger differences underneath all of that: the
+models themselves, the tools built around them, and the direction each company
+seems to be pushing toward.
 
-## understand the layers of every agentic system
-
-it's important to know which layer holds the solution space to your bottlenecks.
-
-| layer | what it covers | examples |
-|---|---|---|
-| surface | cli, ide, and app tradeoffs | terminal, desktop app, ide, web |
-| harness | tools, runtime, and memory | codex, claude code, qwen code |
-| model | valuing inference | hosted, open weight, local |
-| orchestration | how parallel work is planned and coordinated | worktrees, agents, control planes |
-
-## compare setups most commonly used
-
-| setup | advantage | cost |
-|---|---|---|
-| terminal plus first party app | deep local control with one supervision surface | extra app and execution location complexity |
-| ide integrated agent | selection context, diagnostics, and inline review | editor coupling and local resource pressure |
-| terminal only agent | low interface overhead and scriptability | more manual coordination across concurrent work |
-| local or open stack | model choice, privacy, and infrastructure control | hardware, serving, and evaluation ownership |
+this site is basically my attempt to write all of that down while it’s happening.

--- a/scripts/test-a11y.mjs
+++ b/scripts/test-a11y.mjs
@@ -79,9 +79,9 @@ try {
         for (const element of reading.filter(visible)) if (element.getBoundingClientRect().width > 816) findings.push(`reading measure exceeds 68ch: ${element.textContent.trim().slice(0, 60)}`);
 
         checkRole(elements('td, .page-sources li, .run-inventory li, .artifact-list li, .run-page dd'), { size: 16, line: 24, weight: 400, family: 'Instrument Sans', color: ink }, 'dense content');
-        const metadata = elements('.section-label, .home-guide-list span, .home-meta, .sidebar-label, .page-meta, figcaption, .history-year, .run-header > p:first-child, .run-page dt, .run-evidence, .run-inventory span, .source-kinds, th');
+        const metadata = elements('.section-label, .home-guide-list span, .footer-meta, .sidebar-label, .page-meta, figcaption, .history-year, .run-header > p:first-child, .run-page dt, .run-evidence, .run-inventory span, .source-kinds, th');
         checkRole(metadata, { size: 12, line: 18, weight: 400, family: 'IBM Plex Mono', color: slate }, 'metadata');
-        checkRole(elements('.site-name, .provider-tabs a, .handbook-sidebar a, .right-sidebar a, .right-sidebar h2, .site-footer a, .site-footer p'), { size: 14, line: 20, family: 'Instrument Sans' }, 'navigation');
+        checkRole(elements('.site-name, .provider-tabs a, .handbook-sidebar a, .right-sidebar a, .right-sidebar h2, .site-footer a'), { size: 14, line: 20, family: 'Instrument Sans' }, 'navigation');
         return findings;
       }, { route, viewportWidth: viewport.width });
       for (const finding of typographyFailures) failures.push(`${viewport.name} ${route}: ${finding}`);

--- a/scripts/test-site.mjs
+++ b/scripts/test-site.mjs
@@ -47,7 +47,7 @@ for (const [route, source] of contentFiles) {
     }
   }
   if (!route.startsWith('/field-lab/') && !publicText.includes('last updated')) failures.push(`${route}: exact update metadata is missing`);
-  for (const label of ['guides', 'codex', 'claude code', 'grok']) if (!publicText.includes(label)) failures.push(`${route}: provider scope tab is missing: ${label}`);
+  for (const label of ['index', 'codex', 'claude code', 'grok']) if (!publicText.includes(label)) failures.push(`${route}: provider scope tab is missing: ${label}`);
   if (/\bproduct guides\b/i.test(publicText)) failures.push(`${route}: retired product guides label appears in public output`);
   if (html.includes('·')) failures.push(`${route}: mid dot appears in public output`);
   if (!html.includes('coding agent tips on GitHub')) failures.push(`${route}: GitHub link is missing from the site header`);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,18 @@ const home = await getEntry('home', 'home');
 if (!home) throw new Error('content/home.md is required');
 const { Content } = await render(home);
 const guides = await getHomepagePages();
+const guideGroups = [
+  {
+    id: 'provider-guides',
+    title: 'by provider',
+    guides: guides.filter((guide) => guide.data.navigation.scope !== 'general'),
+  },
+  {
+    id: 'shared-guides',
+    title: 'across agents',
+    guides: guides.filter((guide) => guide.data.navigation.scope === 'general'),
+  },
+];
 ---
 
 <BaseLayout title={home.data.title} description={home.data.description}>
@@ -20,28 +32,35 @@ const guides = await getHomepagePages();
       <header class="home-guides-heading">
         <p class="section-label">{site.interfaceCopy.guides}</p>
         <h2 id="guide-title">choose where to begin</h2>
-        <p>start with a provider, compare setups, or read the shared practices that apply across agent systems.</p>
+        <p>pick a provider or a shared guide.</p>
       </header>
-      <div class="home-guide-list">
+      <div class="home-guide-groups">
         {
-          guides.map((guide) => (
-            <a href={routeForEntry(guide)}>
-              <h3>{guide.data.title}</h3>
-              <p>{guide.data.description}</p>
-              <span>{guide.data.navigation.scope}</span>
-              <Icon name="ph:arrow-right" aria-hidden="true" />
-            </a>
+          guideGroups.map((group) => (
+            <section class="home-guide-group" aria-labelledby={group.id}>
+              <h3 id={group.id}>{group.title}</h3>
+              <div class="home-guide-list">
+                {group.guides.map((guide) => (
+                  <a href={routeForEntry(guide)}>
+                    <h3>{guide.data.title}</h3>
+                    <p>{guide.data.description}</p>
+                    <Icon name="ph:arrow-right" aria-hidden="true" />
+                  </a>
+                ))}
+              </div>
+            </section>
           ))
         }
       </div>
     </section>
 
-    <div class="home-meta" aria-label="page metadata">
-      <span>{site.interfaceCopy.lastUpdated} {formatUpdatedAt(home.data.updatedAt)}</span>
-    </div>
   </main>
-  <footer class="site-footer">
-    <p>{site.name}</p>
+  <footer class="site-footer" id="site-footer">
+    <a class="site-name footer-site-name" href="/" aria-label={site.interfaceCopy.home}>
+      <img src="/favicon.svg" alt="" width="24" height="24" />
+      <span>{site.name}</span>
+    </a>
+    <p class="footer-meta">{site.interfaceCopy.lastUpdated} {formatUpdatedAt(home.data.updatedAt)}</p>
     <nav aria-label="footer">
       <a href="/archive/">{site.interfaceCopy.archive}</a>
       <a href={site.releaseHistory}>{site.interfaceCopy.releases}</a>

--- a/src/site.ts
+++ b/src/site.ts
@@ -20,7 +20,7 @@ export const site = {
 } as const;
 
 export const navigationScopes = [
-  { id: 'general', label: site.interfaceCopy.guides, href: '/', order: 10 },
+  { id: 'general', label: 'index', href: '/', order: 10 },
   { id: 'codex', label: 'codex', href: '/guides/codex/', order: 20 },
   { id: 'claude-code', label: 'claude code', href: '/guides/claude-code/', order: 30 },
   { id: 'grok', label: 'grok', href: '/guides/grok/', order: 40 },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -48,7 +48,7 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .header-main { padding: 0 var(--site-gutter); display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
 .site-name { display: inline-flex; align-items: center; gap: .7rem; width: max-content; text-decoration: none; }
 .site-name img { inline-size: 1.5rem; block-size: 1.5rem; flex: none; border-radius: var(--radius-ui); }
-.provider-tabs { min-inline-size: 0; padding: 0 var(--site-gutter); border-top: 1px solid var(--rule); display: flex; align-items: end; justify-content: center; gap: clamp(1.5rem, 4vw, 3.5rem); overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: none; }
+.provider-tabs { min-inline-size: 0; padding: 0 var(--site-gutter); display: flex; align-items: end; justify-content: center; gap: clamp(1.5rem, 4vw, 3.5rem); overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: none; }
 .provider-tabs::-webkit-scrollbar { display: none; }
 .provider-tabs a { position: relative; padding: .78rem .05rem .66rem; color: var(--slate); text-decoration: none; white-space: nowrap; }
 .provider-tabs a::after { content: ''; position: absolute; inset: auto 0 0; block-size: 2px; background: transparent; }
@@ -60,30 +60,33 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .github-link svg { inline-size: 1.35rem; block-size: 1.35rem; }
 .mobile-site-menu { display: none; }
 
-.home-content, .home-guides, .home-meta { width: min(100% - 2rem, 76rem); margin-inline: auto; }
-.home-content { padding: clamp(3.5rem, 8vw, 7rem) 0 5rem; }
+.home-content, .home-guides { width: min(100% - 2rem, 76rem); margin-inline: auto; }
+.home-content { padding: clamp(3.5rem, 8vw, 7rem) 0 0; }
 .home-content h1 { max-width: 68rem; text-wrap: balance; }
-.keyword-highlight { padding: .01em .1em .07em; border-radius: var(--radius-ui); background: var(--cobalt); color: var(--white); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
-.home-content h1 .keyword-highlight { white-space: nowrap; }
+.keyword-highlight { padding: .01em .1em .08em; border-radius: .5rem; background: var(--cobalt); color: var(--white); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
+.home-content h1 .keyword-highlight { display: inline-block; white-space: nowrap; }
 .home-content > p:first-of-type { max-width: 68ch; }
 .home-content h2 + p { max-width: 68ch; }
 .home-content table { width: 100%; margin-top: 1.5rem; border-collapse: collapse; }
 .home-content th { padding: .75rem 1rem; border-top: 1px solid var(--ink); border-bottom: 1px solid var(--rule); text-align: left; }
 .home-content td { padding: .75rem 1rem; border-bottom: 1px solid var(--rule); vertical-align: top; }
-.home-guides { padding: 1rem 0 5rem; }
-.home-guides-heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, 34rem); gap: 1rem 3rem; align-items: end; margin: 4rem 0 1.5rem; }
+.home-guides { padding: 4rem 0 5rem; }
+.home-guides-heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, 34rem); gap: 1rem 3rem; align-items: end; margin: 0 0 2.5rem; }
 .home-guides-heading .section-label { grid-column: 1 / -1; margin: 0; }
 .home-guides-heading h2 { margin: 0; }
 .home-guides-heading > p:last-child { max-width: 34rem; margin: 0 0 .2rem; }
+.home-guide-groups { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 3rem; }
+.home-guide-group > h3 { margin: 0 0 1rem; }
 .home-guide-list { border-top: 1px solid var(--ink); }
-.home-guide-list a { display: grid; grid-template-columns: 1fr 1.5fr 1fr 1.5rem; align-items: start; gap: 1.5rem; padding: 1.25rem 0; border-bottom: 1px solid var(--rule); text-decoration: none; }
+.home-guide-list a { display: grid; grid-template-columns: minmax(0, 1fr) 1.5rem; gap: .35rem 1rem; padding: 1.25rem 0; border-bottom: 1px solid var(--rule); text-decoration: none; }
 .home-guide-list h3, .home-guide-list p { margin: 0; }
-.home-guide-list svg { inline-size: 1rem; color: var(--cobalt); }
+.home-guide-list p { grid-column: 1; }
+.home-guide-list svg { grid-column: 2; grid-row: 1; inline-size: 1rem; color: var(--cobalt); }
 .home-guide-list a:hover h3 { color: var(--cobalt); }
-.home-meta { display: flex; gap: 1.5rem; padding: 1rem 0 3rem; border-top: 1px solid var(--ink); }
-.site-footer { min-height: 9rem; padding: 2.5rem clamp(1.25rem, 7vw, 8rem); display: grid; grid-template-columns: 1fr auto; gap: 2rem; align-items: start; border-top: 1px solid var(--ink); }
+.site-footer { min-height: var(--site-header-height); padding: 1rem var(--site-gutter); display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); gap: 1rem 2rem; align-items: center; }
 .site-footer p { margin: 0; }
-.site-footer nav { display: flex; gap: 2rem; }
+.footer-meta { justify-self: center; }
+.site-footer nav { display: flex; align-items: center; justify-self: end; gap: 1.5rem; }
 .footer-github svg { inline-size: 1.15rem; block-size: 1.15rem; }
 
 /* Starlight publication shell */
@@ -130,11 +133,6 @@ header.header { height: var(--site-header-height); padding: 0 !important; border
 .history-timeline figure img { display: block; inline-size: 100%; max-block-size: 20rem; object-fit: cover; }
 .history-timeline figcaption { padding: .6rem .75rem; }
 
-@media (max-width: 64rem) {
-  .home-guide-list a { grid-template-columns: 1fr 1.5fr 1.5rem; }
-  .home-guide-list span { grid-column: 1 / 3; }
-}
-
 @media (min-width: 72rem) {
   :root { --sl-content-pad-x: 1.5rem; }
 }
@@ -167,16 +165,16 @@ header.header { height: var(--site-header-height); padding: 0 !important; border
   .site-header { min-height: var(--site-header-height); }
   .provider-tabs { justify-content: flex-start; }
   .home-content { padding-top: 3.5rem; }
-  .home-guides-heading { grid-template-columns: 1fr; margin-top: 2.5rem; }
+  .home-guides { padding-top: 3rem; }
+  .home-guides-heading { grid-template-columns: 1fr; margin-top: 0; }
   .home-guides-heading .section-label { grid-column: 1; }
+  .home-guide-groups { grid-template-columns: 1fr; gap: 2.5rem; }
   .home-content table { display: block; overflow-x: auto; }
   .home-content th, .home-content td { min-width: 9.5rem; }
-  .home-guide-list a { grid-template-columns: 1fr 1.5rem; gap: .6rem; }
-  .home-guide-list h3, .home-guide-list p, .home-guide-list span { grid-column: 1; }
-  .home-guide-list svg { grid-column: 2; grid-row: 1; }
-  .home-meta { display: grid; gap: .5rem; }
-  .site-footer { grid-template-columns: 1fr; min-height: 0; }
-  .site-footer nav { flex-wrap: wrap; }
+  .site-footer { grid-template-columns: minmax(0, 1fr) auto; grid-template-areas: 'brand nav' 'meta meta'; gap: .75rem 1rem; }
+  .footer-site-name { grid-area: brand; }
+  .footer-meta { grid-area: meta; justify-self: center; }
+  .site-footer nav { grid-area: nav; flex-wrap: wrap; justify-content: end; gap: 1rem; }
   .sl-markdown-content table { display: block; overflow-x: auto; }
   .run-body table { display: block; max-inline-size: 100%; overflow-x: auto; }
   .surface-bento { grid-template-columns: 1fr; }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -143,7 +143,7 @@ body {
 }
 
 .site-name, .provider-tabs a, .handbook-sidebar a, .right-sidebar a,
-.right-sidebar h2, .site-footer a, .site-footer p {
+.right-sidebar h2, .site-footer a {
   font-family: var(--font-sans);
   font-size: var(--type-navigation-size);
   font-weight: 400;
@@ -175,7 +175,7 @@ body {
   text-transform: none;
 }
 
-.section-label, .home-guide-list span, .home-meta,
+.section-label, .footer-meta,
 .sidebar-label, .page-meta, .surface-bento figcaption, .history-year,
 .history-timeline figcaption, .run-header > p:first-child, .run-page dt,
 .run-evidence, .run-inventory span, .source-kinds,
@@ -195,16 +195,16 @@ body {
 .copy-review-page .copy li > span:first-child,
 :where(.home-content, .sl-markdown-content, .run-body) th { color: var(--slate); }
 
-.section-label, .home-guide-list span, .home-meta, .history-year,
+.section-label, .footer-meta, .history-year,
 .run-header > p:first-child, .run-page dt, .run-evidence { color: var(--slate); }
 
-.section-label, .home-guide-list span, .home-meta, .sidebar-label, .page-meta,
+.section-label, .footer-meta, .sidebar-label, .page-meta,
 .surface-bento figcaption, .history-year, .history-timeline figcaption,
 .run-header > p:first-child, .run-page dt, .run-evidence, .run-inventory span,
 .source-kinds, .copy-review-page .owner, .copy-review-page .voice,
 .copy-review-page .copy li > span:first-child { max-width: none; }
 
-.section-label, .home-guide-list span, .home-meta, .sidebar-label, .page-meta,
+.section-label, .footer-meta, .sidebar-label, .page-meta,
 .history-year, .run-header > p:first-child, .run-page dt, .run-evidence,
 .run-inventory span, .source-kinds,
 :where(.home-content, .sl-markdown-content, .run-body) th { text-transform: uppercase; }


### PR DESCRIPTION
## summary

- replace the generic homepage origin copy with Ani's manually authored framing
- move the setup tables into the dedicated setup guide and organize the homepage index by provider and shared guidance
- refine the highlighted title, align the footer with the header, center the update metadata, and rename the root tab to `index`
- record manual edits as the primary voice reference and update regression checks for the new public vocabulary

## verification

- `node scripts/check-content.mjs`
- `npm run build`
- `npm run test:site`
- `npm run test:a11y`
- `python3 .github/scripts/check_sources.py`
- `npx markdownlint-cli2 ...`
- shell syntax validation
- browser review at 952px and 375px with clean console output
- both commits return GitHub `verified=true`

## boundaries

- no route, schema, archive compatibility, release, repository setting, or provider configuration changes
- the November 5, 2026 compatibility promise is unchanged
