### PR TITLE
fix(site): finish the homepage polish

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -28,7 +28,7 @@ that started with using them to build things for myself, mostly because i was
 curious and wanted to learn faster. then i started using them for my own
 business, for work with record labels, and eventually on software being used by
 YC-backed companies. somewhere along the way, i also became the kind of person
-who checks x every other week to see which model suddenly got better, what
+who checks X every other week to see which model suddenly got better, what
 changed in codex or claude code, which tiny startup just got acquihired for $10B,
 and who the next freakishly smart 24yo everyone is arguing about will be.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,6 @@ const guideGroups = [
       <header class="home-guides-heading">
         <p class="section-label">{site.interfaceCopy.guides}</p>
         <h2 id="guide-title">choose where to begin</h2>
-        <p>pick a provider or a shared guide.</p>
       </header>
       <div class="home-guide-groups">
         {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,10 +71,9 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .home-content th { padding: .75rem 1rem; border-top: 1px solid var(--ink); border-bottom: 1px solid var(--rule); text-align: left; }
 .home-content td { padding: .75rem 1rem; border-bottom: 1px solid var(--rule); vertical-align: top; }
 .home-guides { padding: 4rem 0 5rem; }
-.home-guides-heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, 34rem); gap: 1rem 3rem; align-items: end; margin: 0 0 2.5rem; }
+.home-guides-heading { display: grid; gap: 1rem; margin: 0 0 2.5rem; }
 .home-guides-heading .section-label { grid-column: 1 / -1; margin: 0; }
 .home-guides-heading h2 { margin: 0; }
-.home-guides-heading > p:last-child { max-width: 34rem; margin: 0 0 .2rem; }
 .home-guide-groups { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 3rem; }
 .home-guide-group > h3 { margin: 0 0 1rem; }
 .home-guide-list { border-top: 1px solid var(--ink); }
@@ -166,7 +165,7 @@ header.header { height: var(--site-header-height); padding: 0 !important; border
   .provider-tabs { justify-content: flex-start; }
   .home-content { padding-top: 3.5rem; }
   .home-guides { padding-top: 3rem; }
-  .home-guides-heading { grid-template-columns: 1fr; margin-top: 0; }
+  .home-guides-heading { margin-top: 0; }
   .home-guides-heading .section-label { grid-column: 1; }
   .home-guide-groups { grid-template-columns: 1fr; gap: 2.5rem; }
   .home-content table { display: block; overflow-x: auto; }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -124,7 +124,7 @@ body {
 .sl-markdown-content :where(p, ul, ol) + :where(p, ul, ol),
 .run-page :where(p, ul, ol) + :where(p, ul, ol) { margin-top: 1.125rem; }
 
-.home-content h2 + p, .home-guides-heading > p:last-child, .home-guide-list p, .run-description,
+.home-content h2 + p, .home-guide-list p, .run-description,
 .artifact-list span, .run-grid ul, .run-page section > ul, .page-sources > p:last-child {
   color: var(--ink);
 }
@@ -152,7 +152,7 @@ body {
   text-transform: none;
 }
 
-.site-name, .provider-tabs a[aria-current='page'], .handbook-sidebar a[aria-current='page'],
+.site-name, .site-footer .footer-site-name, .provider-tabs a[aria-current='page'], .handbook-sidebar a[aria-current='page'],
 .right-sidebar a[aria-current='true'] { font-weight: 600; }
 
 .mobile-site-menu nav a {


### PR DESCRIPTION
## summary

- remove the redundant chooser sentence
- capitalize X as the platform name
- make the footer wordmark use the exact header typography role

## verification

- `bun run check`
- `bun run build`
- `bun run test:site`
- `bun run test:a11y`
- centralized typography ownership check
- source registry and README sync checks
- rendered 952px computed-style comparison and overflow check

## boundaries

- no route, schema, archive, compatibility-promise, release, or provider-settings changes
