### PR TITLE
Complete handbook publication contracts and responsive shell

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig({
         Header: './src/components/StarlightHeader.astro',
         PageTitle: './src/components/StarlightPageTitle.astro',
         PageSidebar: './src/components/StarlightPageSidebar.astro',
+        MarkdownContent: './src/components/StarlightMarkdownContent.astro',
         Footer: './src/components/StarlightFooter.astro',
         Sidebar: './src/components/StarlightSidebar.astro',
       },

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -2,9 +2,10 @@
 title: claude code
 description: a practical map of claude code across terminal, desktop, editor, web, and remote workflows.
 products: [claude-code]
-updatedAt: "2026-08-29T19:04:00-04:00"
-checkedAt: "2026-08-28T00:00:00-04:00"
-status: pending
+updatedAt: "2026-08-30T14:33:21-04:00"
+checkedAt: "2026-08-30T14:33:21-04:00"
+status: current
+completion: complete
 evidence: [official-source, open-question]
 sources: [anthropic-claude-overview, anthropic-how-claude-code-works, anthropic-platforms, anthropic-features-overview, anthropic-memory, anthropic-settings, anthropic-skills, anthropic-mcp, anthropic-subagents, anthropic-hooks, anthropic-plugins, anthropic-desktop, anthropic-web, anthropic-remote-control, anthropic-cowork]
 redirects: []
@@ -46,7 +47,16 @@ repository change, an investigation, or a verified engineering decision.
 
 ### the repository gives the task its shape
 
-<!-- Ani voice pass: add the dated repository first observation here. -->
+Claude Code is where I first learned how much the repository can shape the
+agent. the files provide the immediate evidence, while `CLAUDE.md`, rules,
+settings, tools, and verification commands explain how work should happen
+there. that context becomes more valuable across repeated sessions because I
+do not have to rebuild the same operating assumptions in every prompt.
+
+the repository should still stay legible without Claude Code. instructions can
+point at the real commands and conventions, while the diff and its verification
+remain the shared proof. the agent benefits from durable context without
+turning that context into a second undocumented system.
 
 ## where claude code lives
 
@@ -115,7 +125,14 @@ decide how the session behaves.
 
 ### the interface changes what you can see
 
-<!-- Ani voice pass: compare the review experience without repeating surface mechanics. -->
+the terminal keeps the command, working directory, and interruption point
+close. the IDE keeps the selected code and diagnostics close. desktop makes
+several sessions and visual review easier to compare. web makes cloud execution
+visible, while Remote Control exposes a local session through another screen.
+
+I choose between those interfaces based on the evidence I need to judge next.
+the surface can make one kind of review easier, but it does not change the need
+for a named checkout, an inspectable artifact, and a pass condition.
 
 ### the interaction layer changes how claude code behaves
 
@@ -155,15 +172,40 @@ scope, and reason to remain.
 
 ### steering is different from hosting
 
-<!-- Ani voice pass: distinguish the control surface from the execution host. -->
+the browser or phone can be the place where I read, answer, and redirect a
+session without becoming its execution environment. Remote Control leaves the
+Claude Code process on the host machine, so that machine still owns the local
+repository, tools, MCP servers, credentials, and project configuration.
+
+that makes the host part of the task contract. if the process stops or the host
+goes offline, the remote session stops being available. moving the steering
+surface preserves local context only while the local process remains alive.
 
 ### web and Remote Control use different execution models
 
-<!-- Ani voice pass: deepen the current web and Remote Control distinction. -->
+[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)
+runs in Anthropic's cloud environment. [Remote
+Control](https://code.claude.com/docs/en/remote-control) uses the same broader
+web and mobile access pattern to steer a session that executes on my machine.
+the interfaces can look close while the reachable files, credentials, tools,
+and network are completely different.
+
+I use that execution question as the first branch in the decision. Remote
+Control fits work that already depends on my local environment. web fits work
+that should begin in a clean cloud environment, continue without my terminal,
+or run alongside other isolated tasks.
 
 ### mobile keeps the control loop close
 
-<!-- Ani voice pass: record the current mobile capabilities and limitations. -->
+Claude's mobile app can open and steer a Remote Control session and receive a
+push when the task finishes or needs a decision. the active Claude Code process
+still runs on the host, and one interactive process normally supports one
+remote session unless it is running in server mode.
+
+I treat that as a useful control surface whose current limits still need a
+paired field run before I turn them into a personal recommendation. the
+important product fact is already clear: mobile moves attention and approvals;
+it does not silently move execution away from the machine that owns the work.
 
 ## start with what you are trying to finish
 
@@ -180,8 +222,6 @@ decision. Cowork fits broader computer work and finished deliverables. the
 surface choice becomes clearer when I name what I expect to review at the end.
 
 ### Cowork begins with a finished deliverable
-
-<!-- Ani voice pass: develop the finished knowledge work boundary here. -->
 
 that review should include the remaining uncertainty. Claude Code can make a
 large amount of progress while carrying one wrong assumption about the branch,

--- a/docs/guides/claude-code/configuration.md
+++ b/docs/guides/claude-code/configuration.md
@@ -4,7 +4,8 @@ description: where claude code instructions, settings, permissions, hooks, and r
 products: [claude-code]
 updatedAt: "2026-08-29T19:04:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
-status: pending
+status: current
+completion: excerpt
 evidence: [official-source, open-question]
 sources: [anthropic-features-overview, anthropic-permissions, anthropic-memory, anthropic-settings, anthropic-changelog]
 redirects: []
@@ -31,20 +32,6 @@ navigation:
 keep sensitive machine details and credentials outside shared repository files.
 Claude Code documents the permission system.
 
-## understand the scope before changing a value
-
-### user settings follow you
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### project settings travel with the repository
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### local and managed settings change precedence
-
-<!-- Ani voice pass follows this approved structure. -->
-
 ## separate instructions from memory
 
 ### shared rules have one canonical source
@@ -53,30 +40,6 @@ when a repository supports several agents, keep the shared operating rules in
 one canonical file. make `CLAUDE.md` import those rules, then add only genuine
 Claude Code differences. this prevents the same verification command or safety
 boundary from drifting between agent specific files.
-
-### auto memory records useful experience
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## permissions answer two questions
-
-### rules define allow, ask, and deny
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### modes define the session posture
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## keep identity and secrets outside the repository
-
-### authentication belongs to the account
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### credentials belong in external storage
-
-<!-- Ani voice pass follows this approved structure. -->
 
 ## inspect the effective configuration
 

--- a/docs/guides/claude-code/extensions.md
+++ b/docs/guides/claude-code/extensions.md
@@ -5,6 +5,7 @@ products: [claude-code]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [anthropic-features-overview, anthropic-memory, anthropic-skills, anthropic-mcp, anthropic-subagents, anthropic-hooks, anthropic-plugins]

--- a/docs/guides/claude-code/getting-started.md
+++ b/docs/guides/claude-code/getting-started.md
@@ -5,6 +5,7 @@ products: [claude-code]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [anthropic-claude-overview, anthropic-memory]

--- a/docs/guides/claude-code/recommendations.md
+++ b/docs/guides/claude-code/recommendations.md
@@ -4,7 +4,8 @@ description: simple claude code defaults for different technical backgrounds and
 products: [claude-code]
 updatedAt: "2026-08-22T19:55:02-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
-status: pending
+status: current
+completion: excerpt
 evidence: [official-source, analysis, open-question]
 sources: [anthropic-claude-overview, anthropic-platforms, anthropic-desktop, anthropic-remote-control, anthropic-cowork]
 redirects: []
@@ -35,14 +36,6 @@ navigation:
   </div>
 </dl>
 
-### terminal and repository context are my default
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### desktop and remote surfaces have clear supporting jobs
-
-<!-- Ani voice pass follows this approved structure. -->
-
 ## when i switch surfaces
 
 ### the review surface follows the evidence
@@ -51,71 +44,7 @@ use [Cowork](https://support.claude.com/en/articles/13345190-get-started-with-cl
 apps and documents. use [Claude Code](https://code.claude.com/docs/en/overview) when the result belongs in a repository and
 needs engineering review.
 
-### execution location is a separate decision
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## what claude code does unusually well
-
-### repository context compounds across real work
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### dynamic workflows can coordinate real operations
-
-<!-- Revalidate in a current paired field run before the Ani voice pass. -->
-
-## when dynamic workflows earn their complexity
-
-### use them when they simplify a multistep job
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### background work needs a visible owner
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### routines need stable boundaries
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## why i recommend one password
-
-### the full access model belongs across agents
-
-<!-- Link the shared draft only when both routes are approved for publication. -->
-
-## what i would avoid
-
-### context that grows without an owner
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### automation before a pass condition
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## what changed my mind
-
-### provider roles are a lens rather than a rule
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### scoped authority replaced blanket autonomy
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## how i use a paid plan
-
-### treat the week as a resource budget
-
-<!-- Revalidate current plan limits before the Ani voice pass. -->
-
 ## what i am still watching
-
-### mobile and Remote Control keep changing
-
-<!-- Ani voice pass follows this approved structure. -->
 
 ### current workflow features need a paired field run
 

--- a/docs/guides/claude-code/safety.md
+++ b/docs/guides/claude-code/safety.md
@@ -5,6 +5,7 @@ products: [claude-code]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [anthropic-permissions]

--- a/docs/guides/claude-code/workflows.md
+++ b/docs/guides/claude-code/workflows.md
@@ -5,6 +5,7 @@ products: [claude-code]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [anthropic-features-overview, anthropic-platforms, anthropic-desktop, anthropic-web, anthropic-remote-control, anthropic-commands, anthropic-scheduled-tasks, anthropic-routines, anthropic-agents]

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -2,11 +2,12 @@
 title: codex
 description: a practical map of the codex terminal, app, editor, cloud, and mobile surfaces.
 products: [codex]
-updatedAt: "2026-08-29T19:04:00-04:00"
-checkedAt: "2026-08-28T00:00:00-04:00"
+updatedAt: "2026-08-30T14:33:21-04:00"
+checkedAt: "2026-08-30T14:33:21-04:00"
 status: current
+completion: complete
 evidence: [tested, official-source, analysis]
-sources: [openai-chatgpt-overview, openai-codex-product, openai-codex-manual, openai-codex-cli, openai-codex-ide, openai-chatgpt-desktop-app, openai-codex-app, openai-codex-cloud, openai-codex-mobile, openai-codex-agents-md, openai-codex-skills, openai-codex-plugins, openai-codex-hooks, openai-codex-mcp, openai-codex-subagents, openai-work-and-codex]
+sources: [openai-chatgpt-overview, openai-codex-product, openai-codex-manual, openai-codex-cli, openai-codex-ide, openai-chatgpt-desktop-app, openai-codex-app, openai-codex-cloud, openai-codex-mobile, openai-remote-connections, openai-codex-agents-md, openai-codex-skills, openai-codex-plugins, openai-codex-hooks, openai-codex-mcp, openai-codex-subagents, openai-work-and-codex]
 redirects: []
 voice: personal
 navigation:
@@ -49,7 +50,15 @@ becomes dependable when the environment gives that motion a visible boundary.
 
 ### the task can be its own workspace
 
-<!-- Ani voice pass: introduce the dated projectless task observation here. -->
+Codex does not always need a repository before it can become useful. I can
+begin with a file, a question, a browser, or a piece of visual context and let
+the task become a temporary workspace around the problem. that is useful for
+triage, comparison, and the work that decides which repository should change.
+
+I still name the durable destination as soon as the task becomes code. a
+projectless conversation can hold the investigation, while the implementation
+should settle into a repository, a checkout, and a verification command that
+another person can inspect.
 
 ## where codex lives
 
@@ -171,15 +180,44 @@ switch interfaces without rebuilding the rules of the project from memory.
 
 ### steering is different from hosting
 
-<!-- Ani voice pass: distinguish the control surface from the execution host. -->
+the device in my hand does not have to be the machine doing the work. with
+[Remote](https://learn.chatgpt.com/docs/remote-connections), my phone or another
+desktop can send prompts, approvals, and follow up instructions to a connected
+host. the host still supplies the files, shell, credentials, permissions,
+skills, MCP servers, browser setup, and local tools.
+
+this distinction keeps remote work understandable. I first ask where the
+process is running and which environment it can reach. only then do I decide
+which screen is the most convenient place to steer it.
 
 ### local, remote, and cloud execution are different
 
-<!-- Ani voice pass: orient the reader before the full workflows comparison. -->
+local work uses the machine in front of me. Control Other Devices keeps the
+work on a connected desktop host and moves the controls somewhere else. an SSH
+project goes further: the desktop app starts Codex through SSH, then reads,
+writes, and runs commands against the remote machine. [Codex
+cloud](https://learn.chatgpt.com/docs/cloud) uses a separate hosted environment
+that can continue after I close the desktop app.
+
+those options solve different problems. a connected host preserves the setup I
+already trust. SSH is useful when the repository and its dependencies already
+live on another machine. cloud work is useful when the task should be isolated
+from my computer and continue independently. convenience comes after choosing
+the right execution boundary.
 
 ### mobile keeps the control loop close
 
-<!-- Ani voice pass: preserve the direct mobile experience and dated feature notes. -->
+mobile Codex is genuinely useful to me because it keeps much more of the control
+loop available than a simple notification screen. I can start or continue
+chats, choose branches and worktrees, inspect diffs and terminal output, manage
+goals, leave review comments, answer questions, and approve actions while the
+connected host keeps its full environment.
+
+the phone works best for steering and review. I still return to a larger screen
+for a wide diff, a long terminal trace, or a decision that depends on several
+files at once. mobile shortens the distance between the task needing attention
+and me making the next decision without pretending that every review belongs on
+a phone.
 
 ## start with what you are trying to finish
 
@@ -198,8 +236,6 @@ verification result; knowledge work should end in a deliverable I can read,
 edit, and share.
 
 ### ChatGPT Work begins with a finished deliverable
-
-<!-- Ani voice pass: develop the finished knowledge work boundary here. -->
 
 the final authority stays easy to name in either case. an agent can prepare a
 commit, a pull request, a deployment, a message, or a deletion. preparing that

--- a/docs/guides/codex/configuration.md
+++ b/docs/guides/codex/configuration.md
@@ -5,6 +5,7 @@ products: [codex]
 updatedAt: "2026-08-29T19:04:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: current
+completion: excerpt
 evidence: [tested, official-source, analysis]
 sources: [openai-codex-manual, openai-codex-agents-md, openai-codex-skills, openai-codex-plugins, openai-codex-mcp, openai-codex-config, openai-codex-security]
 redirects: []
@@ -32,30 +33,6 @@ files also cannot override provider, authentication, or profile keys. this
 keeps shared repository configuration narrower than personal account settings.
 the [configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference) describes each value.
 
-## understand the scope before changing a value
-
-### personal configuration follows you
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### project configuration begins with trust
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### profiles group deliberate modes
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## separate instructions from memory
-
-### shared rules have one canonical source
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### memory records useful experience
-
-<!-- Ani voice pass follows this approved structure. -->
-
 ## permissions are two different questions
 
 ### the sandbox defines reach
@@ -74,19 +51,9 @@ app and CLI installation may be on different versions. the [security guide](http
 
 ## keep identity and secrets outside the repository
 
-### authentication belongs to the account
-
-<!-- Ani voice pass follows this approved structure. -->
-
 ### credentials belong in external storage
 
 keep stable team rules in version control. keep machine specific paths,
 credentials, and account choices outside the repository. after any handoff
 between terminal, app, editor, or remote machine, confirm the working directory,
 branch, permissions, and verification command before editing.
-
-## inspect the effective configuration
-
-### profiles can change several assumptions at once
-
-<!-- Ani voice pass follows this approved structure. -->

--- a/docs/guides/codex/extensions.md
+++ b/docs/guides/codex/extensions.md
@@ -5,6 +5,7 @@ products: [codex]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [openai-codex-manual, openai-codex-agents-md, openai-codex-skills, openai-codex-mcp, openai-codex-hooks, openai-codex-subagents, openai-codex-plugins]

--- a/docs/guides/codex/getting-started.md
+++ b/docs/guides/codex/getting-started.md
@@ -5,6 +5,7 @@ products: [codex]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [openai-codex-manual, openai-codex-config]

--- a/docs/guides/codex/recommendations.md
+++ b/docs/guides/codex/recommendations.md
@@ -5,6 +5,7 @@ products: [codex]
 updatedAt: "2026-08-22T19:55:02-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: current
+completion: excerpt
 evidence: [tested, official-source, analysis]
 sources: [openai-codex-product, openai-codex-manual, openai-codex-cli, openai-codex-ide, openai-chatgpt-desktop-app, openai-codex-agents-md, openai-codex-mobile, openai-codex-app, openai-work-and-codex, git-worktrees]
 redirects: []
@@ -35,14 +36,6 @@ navigation:
   </div>
 </dl>
 
-### desktop is the coordination hub
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### CLI and mobile have clear supporting jobs
-
-<!-- Ani voice pass follows this approved structure. -->
-
 ## when i switch surfaces
 
 ### the review surface follows the evidence
@@ -51,40 +44,6 @@ use [ChatGPT Work](https://help.openai.com/en/articles/20001275-chatgpt-work-and
 presentation, or research artifact. use [Codex](https://openai.com/codex/) when the source of truth is a
 repository and the result must survive tests, review, and version control.
 
-### execution location is a separate decision
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## what codex does unusually well
-
-### projectless work broadens the starting point
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### visible orchestration makes parallel work easier to judge
-
-<!-- Revalidate in a current paired field run before the Ani voice pass. -->
-
-## where image generation earns its place
-
-### generate visual direction from project context
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### edit and refine existing images
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### turn visual experiments into reviewed assets
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## why i recommend one password
-
-### the full access model belongs across agents
-
-<!-- Link the shared draft only when both routes are approved for publication. -->
-
 ## what i would avoid
 
 ### parallelism that outruns review
@@ -92,33 +51,3 @@ repository and the result must survive tests, review, and version control.
 for consequential work, start with one outcome and one pass condition. add
 parallel agents after the repository has deterministic checks and clear file
 ownership.
-
-### standing access without a bounded job
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## what changed my mind
-
-### worktrees replaced direct main work
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### scoped authority replaced blanket autonomy
-
-<!-- Ani voice pass follows this approved structure. -->
-
-## how i use a paid plan
-
-### treat the week as a resource budget
-
-<!-- Revalidate current plan limits before the Ani voice pass. -->
-
-## what i am still watching
-
-### mobile and remote execution keep changing
-
-<!-- Ani voice pass follows this approved structure. -->
-
-### security and model behavior need dated claims
-
-<!-- Ani voice pass follows this approved structure. -->

--- a/docs/guides/codex/safety.md
+++ b/docs/guides/codex/safety.md
@@ -5,6 +5,7 @@ products: [codex]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [openai-codex-manual, openai-codex-security]

--- a/docs/guides/codex/workflows.md
+++ b/docs/guides/codex/workflows.md
@@ -5,6 +5,7 @@ products: [codex]
 updatedAt: "2026-08-27T12:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, open-question]
 sources: [openai-codex-manual, openai-codex-cloud, openai-codex-mobile]

--- a/docs/guides/credentials-and-access.md
+++ b/docs/guides/credentials-and-access.md
@@ -5,6 +5,7 @@ products: [codex, claude-code]
 updatedAt: "2026-08-28T00:00:00-04:00"
 checkedAt: "2026-08-28T00:00:00-04:00"
 status: pending
+completion: outline
 draft: true
 evidence: [official-source, analysis, open-question]
 sources: [onepassword-codex, onepassword-claude, onepassword-cli-secrets]

--- a/docs/sources.json
+++ b/docs/sources.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "checked_on": "2026-08-28",
+  "checked_on": "2026-08-30",
   "product_versions": {
     "codex": "0.149.0",
     "claude_code": "2.1.240"
@@ -36,7 +36,7 @@
         "https://learn.chatgpt.com/docs/codex",
         "https://github.com/openai/codex"
       ],
-      "last_checked": "2026-08-07",
+      "last_checked": "2026-08-30",
       "evidence": "official-source",
       "watch": {
         "kind": "terms",
@@ -178,6 +178,28 @@
       "url": "https://learn.chatgpt.com/docs/cloud",
       "last_checked": "2026-08-27",
       "evidence": "official-source"
+    },
+    {
+      "id": "openai-remote-connections",
+      "title": "Remote connections",
+      "publisher": "openai",
+      "product": "codex",
+      "layer": "surface",
+      "status": "watchlist",
+      "url": "https://learn.chatgpt.com/docs/remote-connections",
+      "aliases": [
+        "https://learn.chatgpt.com/docs/remote-connections.md"
+      ],
+      "last_checked": "2026-08-30",
+      "evidence": "official-source",
+      "watch": {
+        "kind": "terms",
+        "terms": [
+          "Control other devices",
+          "SSH host",
+          "Remote"
+        ]
+      }
     },
     {
       "id": "anthropic-claude-overview",
@@ -403,7 +425,7 @@
       "layer": "surface",
       "status": "core",
       "url": "https://code.claude.com/docs/en/remote-control",
-      "last_checked": "2026-08-22",
+      "last_checked": "2026-08-30",
       "evidence": "official-source",
       "watch": {
         "kind": "terms",

--- a/editorial/handbook-blueprints.json
+++ b/editorial/handbook-blueprints.json
@@ -1,0 +1,141 @@
+{
+  "version": 1,
+  "headingFormat": "Each heading inherits the guide evidenceType and sourceIds. Experience questions apply to every heading in the guide unless a more specific question is recorded during its checkpoint.",
+  "guides": [
+    {
+      "file": "docs/guides/codex.md",
+      "provider": "codex",
+      "chapter": "overview",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["openai-codex-manual", "openai-codex-cli", "openai-codex-ide", "openai-chatgpt-desktop-app", "openai-codex-cloud", "openai-codex-mobile", "openai-remote-connections", "openai-work-and-codex"],
+      "experienceQuestions": ["Which surface did Ani use for the work described?", "Where did execution live?", "What evidence or decision returned to Ani?"],
+      "headings": ["## this is codex", "### one engineering loop, several control rooms", "### the task can be its own workspace", "## where codex lives", "### terminal and editor keep the evidence close", "### desktop coordinates parallel work", "### cloud and mobile change where you steer", "## the interface is not the whole system", "### the interface changes what you can see", "### the interaction layer changes what codex can reach", "## controlling codex across devices", "### steering is different from hosting", "### local, remote, and cloud execution are different", "### mobile keeps the control loop close", "## start with what you are trying to finish", "### code should end in the repository", "### ChatGPT Work begins with a finished deliverable"]
+    },
+    {
+      "file": "docs/guides/claude-code.md",
+      "provider": "claude-code",
+      "chapter": "overview",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["anthropic-claude-overview", "anthropic-how-claude-code-works", "anthropic-platforms", "anthropic-desktop", "anthropic-web", "anthropic-remote-control", "anthropic-cowork"],
+      "experienceQuestions": ["Which Claude Code surface did Ani actually use?", "What repository context shaped the result?", "Was execution local, remote-controlled, or cloud-hosted?"],
+      "headings": ["## this is claude code", "### one engineering loop, several interfaces", "### the repository gives the task its shape", "## where claude code lives", "### terminal and IDE keep the evidence close", "### desktop coordinates parallel work", "### web, mobile, and Remote Control change where you steer", "## the interface is not the whole system", "### the interface changes what you can see", "### the interaction layer changes how claude code behaves", "## controlling claude code across devices", "### steering is different from hosting", "### web and Remote Control use different execution models", "### mobile keeps the control loop close", "## start with what you are trying to finish", "### code should end in the repository", "### Cowork begins with a finished deliverable"]
+    },
+    {
+      "file": "docs/guides/codex/getting-started.md",
+      "provider": "codex",
+      "chapter": "getting-started",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["openai-codex-manual", "openai-codex-agents-md"],
+      "experienceQuestions": ["What was the first useful repository pass?", "What artifact and verification command made it complete?"],
+      "headings": ["## begin with one useful pass", "### use work you already understand", "### give it one visible finish line", "## choose the surface by how you want to review", "### keep commands and diffs close", "### use a visual surface when the review is visual", "### move the steering surface when it helps", "## give the repository durable context", "### AGENTS.md explains the repository", "### task context belongs to the current pass", "## define completion before the first prompt", "### name the artifact", "### name the verification command", "### name the decision that returns to you", "## close the loop with receipts", "### read the diff", "### rerun the proof", "### carry the open questions forward"]
+    },
+    {
+      "file": "docs/guides/claude-code/getting-started.md",
+      "provider": "claude-code",
+      "chapter": "getting-started",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["anthropic-claude-overview", "anthropic-memory"],
+      "experienceQuestions": ["What was the first useful repository pass?", "What belonged in CLAUDE.md rather than the prompt?"],
+      "headings": ["## begin with one useful pass", "### use work you already understand", "### give it one visible finish line", "## choose the surface by how you want to review", "### keep commands and diffs close", "### use a visual surface when the review is visual", "### move the steering surface when it helps", "## give the repository durable context", "### CLAUDE.md explains the repository", "### task context belongs to the current pass", "## define completion before the first prompt", "### name the artifact", "### name the verification command", "### name the decision that returns to you", "## close the loop with receipts", "### read the diff", "### rerun the proof", "### carry the open questions forward"]
+    },
+    {
+      "file": "docs/guides/codex/configuration.md",
+      "provider": "codex",
+      "chapter": "configuration",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["openai-codex-manual", "openai-codex-config", "openai-codex-security"],
+      "experienceQuestions": ["Which defaults follow Ani across repositories?", "Which repository values are trusted and inspectable?", "How are memory and instructions kept distinct?"],
+      "headings": ["## configuration has separate jobs", "### AGENTS.md explains the repository", "### config.toml chooses defaults", "## understand the scope before changing a value", "### personal configuration follows you", "### project configuration begins with trust", "### profiles group deliberate modes", "## separate instructions from memory", "### shared rules have one canonical source", "### memory records useful experience", "## permissions are two different questions", "### the sandbox defines reach", "### approval policy defines interruption", "## keep identity and secrets outside the repository", "### authentication belongs to the account", "### credentials belong in external storage", "## inspect the effective configuration", "### profiles can change several assumptions at once"]
+    },
+    {
+      "file": "docs/guides/claude-code/configuration.md",
+      "provider": "claude-code",
+      "chapter": "configuration",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["anthropic-settings", "anthropic-memory", "anthropic-permissions"],
+      "experienceQuestions": ["Which settings belong to the user, repository, machine, or organization?", "When did precedence or auto memory surprise Ani?"],
+      "headings": ["## configuration has separate jobs", "### CLAUDE.md explains the repository", "### settings choose behavior", "## understand the scope before changing a value", "### user settings follow you", "### project settings travel with the repository", "### local and managed settings change precedence", "## separate instructions from memory", "### shared rules have one canonical source", "### auto memory records useful experience", "## permissions answer two questions", "### rules define allow, ask, and deny", "### modes define the session posture", "## keep identity and secrets outside the repository", "### authentication belongs to the account", "### credentials belong in external storage", "## inspect the effective configuration", "### imports and precedence can hide the source"]
+    },
+    {
+      "file": "docs/guides/codex/safety.md",
+      "provider": "codex",
+      "chapter": "safety",
+      "evidenceType": "analysis-with-official-source",
+      "sourceIds": ["openai-codex-security", "openai-codex-manual"],
+      "experienceQuestions": ["What authority did Ani deliberately retain?", "How did unattended or remote execution change the reachable world?"],
+      "headings": ["## access should match the job", "### filesystem, network, and external systems are separate kinds of reach", "### remote and cloud execution change the reachable world", "## identity travels with the action", "### name the human, machine, and service identity", "### scoped identities fit unattended work", "## unattended work changes the risk", "### scheduled work needs predeclared boundaries", "### event triggered work needs a narrow reachable world", "## external actions need their own decision", "### preparing and executing are separate states", "### final authority belongs to the named human", "### merge, publish, deploy, send, pay, purchase, delete, and account changes return to the human", "## security review is its own workflow", "### Codex Security surfaces hypotheses", "### a finding still needs validation", "## finish with authority clear", "### name what happened under which identity", "### return the remaining decision"]
+    },
+    {
+      "file": "docs/guides/claude-code/safety.md",
+      "provider": "claude-code",
+      "chapter": "safety",
+      "evidenceType": "analysis-with-official-source",
+      "sourceIds": ["anthropic-permissions"],
+      "experienceQuestions": ["Which permissions and policies made work understandable?", "Which final actions remained human decisions?"],
+      "headings": ["## access should match the job", "### filesystem, network, and external systems are separate kinds of reach", "### remote and cloud execution change the reachable world", "## identity travels with the action", "### name the human, machine, and service identity", "### scoped identities fit unattended work", "## unattended work changes the risk", "### scheduled work needs predeclared boundaries", "### event triggered work needs a narrow reachable world", "## external actions need their own decision", "### preparing and executing are separate states", "### final authority belongs to the named human", "### merge, publish, deploy, send, pay, purchase, delete, and account changes return to the human", "## policy can set an organization floor", "### managed policy defines the floor", "### hooks can enforce specific events", "## finish with authority clear", "### name what happened under which identity", "### return the remaining decision"]
+    },
+    {
+      "file": "docs/guides/codex/workflows.md",
+      "provider": "codex",
+      "chapter": "workflows",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["openai-codex-manual", "openai-codex-cloud", "openai-codex-mobile"],
+      "experienceQuestions": ["What did Ani run in parallel or away from the primary machine?", "Where did image generation produce a reviewed project asset?"],
+      "headings": ["## the everyday loop", "### scope the pass before the prompt", "### keep evidence close to the work", "## parallel work needs visible boundaries", "### one task owns one checkout", "### review capacity is the real limit", "## work that continues without you", "### goals preserve a durable objective", "### scheduled work needs a stable environment", "### cloud tasks return as new evidence", "## working across devices", "### mobile is a full codex surface", "### control other devices connects to a codex host", "### Remote SSH opens the remote machine directly", "### choose where execution should live", "## image generation belongs inside the build loop", "### generate from the project context", "### edit and refine existing images", "### turn visual output into reviewed assets", "## handoffs preserve state and authority", "### name the repository state", "### return with evidence and the remaining decision"]
+    },
+    {
+      "file": "docs/guides/claude-code/workflows.md",
+      "provider": "claude-code",
+      "chapter": "workflows",
+      "evidenceType": "official-source-pending-field-run",
+      "sourceIds": ["anthropic-features-overview", "anthropic-desktop", "anthropic-web", "anthropic-remote-control", "anthropic-commands", "anthropic-scheduled-tasks", "anthropic-routines", "anthropic-agents"],
+      "experienceQuestions": ["Which dynamic workflow features has Ani actually run?", "What state survived resume, branch, Remote Control, or teleport?"],
+      "headings": ["## the everyday loop", "### scope the pass before the prompt", "### keep evidence close to the work", "## parallel work needs visible boundaries", "### subagents protect the main context", "### background agents keep work moving", "### worktrees separate change ownership", "## dynamic workflows coordinate more than one step", "### agent view makes parallel work visible", "### batch work needs independent units", "### repeatable loops need explicit routing", "## work that continues without you", "### loop watches the current session", "### desktop scheduled tasks stay local", "### routines continue in the cloud", "## working across devices", "### Remote Control keeps execution local", "### Dispatch starts work from mobile", "### web moves execution to the cloud", "### teleport changes the steering surface", "## handoffs preserve state and authority", "### resume, branch, and teleport carry different state", "### return with evidence and the remaining decision"]
+    },
+    {
+      "file": "docs/guides/codex/extensions.md",
+      "provider": "codex",
+      "chapter": "extensions",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["openai-codex-agents-md", "openai-codex-skills", "openai-codex-mcp", "openai-codex-hooks", "openai-codex-subagents", "openai-codex-plugins"],
+      "experienceQuestions": ["Which mechanism solved a real recurring job?", "What context or maintenance cost did it add?"],
+      "headings": ["## make operating knowledge reusable", "### instructions route the repository context", "### skills carry procedures, scripts, and references", "## connect a real system", "### MCP exposes tools and resources", "### authentication and reach stay explicit", "## make events deterministic", "### hooks run code at defined moments", "### failure should remain visible", "## give work its own context", "### subagents need a bounded problem", "### the return contract matters", "## package behavior for reuse", "### plugins move related behavior together", "### portable behavior needs an owner and version", "## compose without losing the plot", "### route context instead of preloading it", "### every layer needs one clear job", "### maintenance cost is part of the design"]
+    },
+    {
+      "file": "docs/guides/claude-code/extensions.md",
+      "provider": "claude-code",
+      "chapter": "extensions",
+      "evidenceType": "tested-and-official-source",
+      "sourceIds": ["anthropic-memory", "anthropic-skills", "anthropic-mcp", "anthropic-subagents", "anthropic-hooks", "anthropic-plugins"],
+      "experienceQuestions": ["Which layer did Ani choose and why?", "How did precedence, context cost, ownership, or removal affect the design?"],
+      "headings": ["## make repository context durable", "### CLAUDE.md and rules establish context", "### skills carry procedures", "### imports keep shared knowledge singular", "## connect a real system", "### MCP exposes tools and resources", "### authentication and reach stay explicit", "## make events deterministic", "### hooks run code at defined moments", "### failure should remain visible", "## give work its own context", "### subagents need a bounded problem", "### the return contract matters", "## package behavior for reuse", "### plugins move related behavior together", "### portable behavior needs an owner and version", "## compose without losing the plot", "### precedence decides which layer wins", "### context cost is part of the design", "### ownership makes removal possible"]
+    },
+    {
+      "file": "docs/guides/codex/recommendations.md",
+      "provider": "codex",
+      "chapter": "recommendations",
+      "evidenceType": "personal-with-dated-sources",
+      "sourceIds": ["openai-codex-product", "openai-codex-manual", "openai-codex-mobile", "openai-codex-app", "openai-work-and-codex", "onepassword-codex", "git-worktrees"],
+      "experienceQuestions": ["What does Ani actually default to, switch, avoid, and pay for?", "Which opinion changed after a field run?"],
+      "headings": ["## my default codex setup", "### desktop is the coordination hub", "### CLI and mobile have clear supporting jobs", "## when i switch surfaces", "### the review surface follows the evidence", "### execution location is a separate decision", "## what codex does unusually well", "### projectless work broadens the starting point", "### visible orchestration makes parallel work easier to judge", "## where image generation earns its place", "### generate visual direction from project context", "### edit and refine existing images", "### turn visual experiments into reviewed assets", "## why i recommend one password", "### the full access model belongs across agents", "## what i would avoid", "### parallelism that outruns review", "### standing access without a bounded job", "## what changed my mind", "### worktrees replaced direct main work", "### scoped authority replaced blanket autonomy", "## how i use a paid plan", "### treat the week as a resource budget", "## what i am still watching", "### mobile and remote execution keep changing", "### security and model behavior need dated claims"]
+    },
+    {
+      "file": "docs/guides/claude-code/recommendations.md",
+      "provider": "claude-code",
+      "chapter": "recommendations",
+      "evidenceType": "personal-with-dated-sources",
+      "sourceIds": ["anthropic-claude-overview", "anthropic-platforms", "anthropic-desktop", "anthropic-remote-control", "anthropic-cowork", "onepassword-claude"],
+      "experienceQuestions": ["What does Ani actually default to, switch, avoid, and pay for?", "Which dynamic workflow claims still need a paired field run?"],
+      "headings": ["## my default claude code setup", "### terminal and repository context are my default", "### desktop and remote surfaces have clear supporting jobs", "## when i switch surfaces", "### the review surface follows the evidence", "### execution location is a separate decision", "## what claude code does unusually well", "### repository context compounds across real work", "### dynamic workflows can coordinate real operations", "## when dynamic workflows earn their complexity", "### use them when they simplify a multistep job", "### background work needs a visible owner", "### routines need stable boundaries", "## why i recommend one password", "### the full access model belongs across agents", "## what i would avoid", "### context that grows without an owner", "### automation before a pass condition", "## what changed my mind", "### provider roles are a lens rather than a rule", "### scoped authority replaced blanket autonomy", "## how i use a paid plan", "### treat the week as a resource budget", "## what i am still watching", "### mobile and Remote Control keep changing", "### current workflow features need a paired field run"]
+    },
+    {
+      "file": "docs/guides/credentials-and-access.md",
+      "provider": "shared",
+      "chapter": "credentials-and-access",
+      "evidenceType": "personal-with-official-source",
+      "sourceIds": ["onepassword-codex", "onepassword-claude", "onepassword-cli-secrets"],
+      "experienceQuestions": ["Which 1Password workflows has Ani personally used?", "What changed with a dedicated host?", "Which integration limits still need verification?"],
+      "headings": ["## credentials belong in an access layer", "### scope access to the current job", "### the broker supplies access while the secret stays encrypted", "## interactive access keeps the human close", "### biometric approval is fast enough to use", "### browser access should be scoped per task", "## automation needs a machine identity", "### service accounts narrow vault access", "### CLI, Environments, and Connect solve different jobs", "## why i pay for one password", "### one access layer keeps machines and agents cleaner", "### the value grows with a dedicated host", "## what changed my mind", "### the model expanded beyond CLI and Connect", "### provider integrations made scoped access practical", "## what i am still testing", "### integration limits need current verification"]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check": "node node_modules/astro/bin/astro.mjs check",
     "check:field-runs": "node scripts/check-field-runs.mjs",
     "check:handbook": "node scripts/check-handbook-structure.mjs",
+    "check:completeness": "node scripts/check-handbook-completeness.mjs",
     "check:readme": "bun scripts/sync-readme.ts --check",
     "check:content": "node scripts/check-content.mjs",
     "check:links": "node scripts/check-editorial-links.mjs",

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -14,6 +14,7 @@ const childEnvironment = {
 const checks = [
   [bun, ['run', 'check']],
   [bun, ['run', 'check:handbook']],
+  [bun, ['run', 'check:completeness']],
   [bun, ['run', 'check:field-runs']],
   [bun, ['run', 'check:readme']],
   [bun, ['run', 'check:links']],

--- a/scripts/check-handbook-completeness.mjs
+++ b/scripts/check-handbook-completeness.mjs
@@ -1,0 +1,68 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const blueprint = JSON.parse(await readFile(path.join(root, 'editorial/handbook-blueprints.json'), 'utf8'));
+const failures = [];
+
+function scalar(markdown, key) {
+  return markdown.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '';
+}
+
+function withoutComments(lines) {
+  let inComment = false;
+  return lines.filter((line) => {
+    if (line.includes('<!--')) inComment = true;
+    const keep = !inComment && line.trim().length > 0;
+    if (line.includes('-->')) inComment = false;
+    return keep;
+  });
+}
+
+function indexedHeadings(lines) {
+  const result = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(##|###) (.+)$/);
+    if (match) result.push({ index, level: match[1].length, text: match[2] });
+  }
+  return result;
+}
+
+for (const guide of blueprint.guides) {
+  const markdown = await readFile(path.join(root, guide.file), 'utf8');
+  const completion = scalar(markdown, 'completion');
+  if (completion === 'outline') continue;
+
+  if (/Ani voice pass/i.test(markdown)) failures.push(`${guide.file}: public page contains an Ani voice placeholder`);
+  if (scalar(markdown, 'status') === 'pending') failures.push(`${guide.file}: public page cannot have pending status`);
+
+  const lines = markdown.split(/\r?\n/);
+  const headings = indexedHeadings(lines);
+  for (let index = 0; index < headings.length; index += 1) {
+    const heading = headings[index];
+    const nextHeading = headings[index + 1];
+    const end = nextHeading?.index ?? lines.length;
+    const body = withoutComments(lines.slice(heading.index + 1, end));
+
+    if (heading.level === 3 && body.length === 0) {
+      failures.push(`${guide.file}:${heading.index + 1}: empty H3 "${heading.text}"`);
+    }
+
+    if (heading.level === 2) {
+      const nextH2 = headings.slice(index + 1).find((candidate) => candidate.level === 2);
+      const sectionEnd = nextH2?.index ?? lines.length;
+      const children = headings.filter((candidate) => candidate.level === 3 && candidate.index > heading.index && candidate.index < sectionEnd);
+      if (!children.length && withoutComments(lines.slice(heading.index + 1, sectionEnd)).length === 0) {
+        failures.push(`${guide.file}:${heading.index + 1}: empty H2 "${heading.text}"`);
+      }
+    }
+  }
+}
+
+if (failures.length) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log('validated substantive content for every public handbook heading');

--- a/scripts/check-handbook-structure.mjs
+++ b/scripts/check-handbook-structure.mjs
@@ -3,155 +3,78 @@ import path from 'node:path';
 import process from 'node:process';
 
 const root = process.cwd();
-const h2 = (text) => `## ${text}`;
-const h3 = (text) => `### ${text}`;
-
-const overviewCodex = [
-  h2('this is codex'), h3('one engineering loop, several control rooms'), h3('the task can be its own workspace'),
-  h2('where codex lives'), h3('terminal and editor keep the evidence close'), h3('desktop coordinates parallel work'), h3('cloud and mobile change where you steer'),
-  h2('the interface is not the whole system'), h3('the interface changes what you can see'), h3('the interaction layer changes what codex can reach'),
-  h2('controlling codex across devices'), h3('steering is different from hosting'), h3('local, remote, and cloud execution are different'), h3('mobile keeps the control loop close'),
-  h2('start with what you are trying to finish'), h3('code should end in the repository'), h3('ChatGPT Work begins with a finished deliverable'),
-];
-
-const overviewClaude = [
-  h2('this is claude code'), h3('one engineering loop, several interfaces'), h3('the repository gives the task its shape'),
-  h2('where claude code lives'), h3('terminal and IDE keep the evidence close'), h3('desktop coordinates parallel work'), h3('web, mobile, and Remote Control change where you steer'),
-  h2('the interface is not the whole system'), h3('the interface changes what you can see'), h3('the interaction layer changes how claude code behaves'),
-  h2('controlling claude code across devices'), h3('steering is different from hosting'), h3('web and Remote Control use different execution models'), h3('mobile keeps the control loop close'),
-  h2('start with what you are trying to finish'), h3('code should end in the repository'), h3('Cowork begins with a finished deliverable'),
-];
-
-const gettingStarted = (instruction) => [
-  h2('begin with one useful pass'), h3('use work you already understand'), h3('give it one visible finish line'),
-  h2('choose the surface by how you want to review'), h3('keep commands and diffs close'), h3('use a visual surface when the review is visual'), h3('move the steering surface when it helps'),
-  h2('give the repository durable context'), h3(instruction), h3('task context belongs to the current pass'),
-  h2('define completion before the first prompt'), h3('name the artifact'), h3('name the verification command'), h3('name the decision that returns to you'),
-  h2('close the loop with receipts'), h3('read the diff'), h3('rerun the proof'), h3('carry the open questions forward'),
-];
-
-const configurationCodex = [
-  h2('configuration has separate jobs'), h3('AGENTS.md explains the repository'), h3('config.toml chooses defaults'),
-  h2('understand the scope before changing a value'), h3('personal configuration follows you'), h3('project configuration begins with trust'), h3('profiles group deliberate modes'),
-  h2('separate instructions from memory'), h3('shared rules have one canonical source'), h3('memory records useful experience'),
-  h2('permissions are two different questions'), h3('the sandbox defines reach'), h3('approval policy defines interruption'),
-  h2('keep identity and secrets outside the repository'), h3('authentication belongs to the account'), h3('credentials belong in external storage'),
-  h2('inspect the effective configuration'), h3('profiles can change several assumptions at once'),
-];
-
-const configurationClaude = [
-  h2('configuration has separate jobs'), h3('CLAUDE.md explains the repository'), h3('settings choose behavior'),
-  h2('understand the scope before changing a value'), h3('user settings follow you'), h3('project settings travel with the repository'), h3('local and managed settings change precedence'),
-  h2('separate instructions from memory'), h3('shared rules have one canonical source'), h3('auto memory records useful experience'),
-  h2('permissions answer two questions'), h3('rules define allow, ask, and deny'), h3('modes define the session posture'),
-  h2('keep identity and secrets outside the repository'), h3('authentication belongs to the account'), h3('credentials belong in external storage'),
-  h2('inspect the effective configuration'), h3('imports and precedence can hide the source'),
-];
-
-const workflowsCodex = [
-  h2('the everyday loop'), h3('scope the pass before the prompt'), h3('keep evidence close to the work'),
-  h2('parallel work needs visible boundaries'), h3('one task owns one checkout'), h3('review capacity is the real limit'),
-  h2('work that continues without you'), h3('goals preserve a durable objective'), h3('scheduled work needs a stable environment'), h3('cloud tasks return as new evidence'),
-  h2('working across devices'), h3('mobile is a full codex surface'), h3('control other devices connects to a codex host'), h3('Remote SSH opens the remote machine directly'), h3('choose where execution should live'),
-  h2('image generation belongs inside the build loop'), h3('generate from the project context'), h3('edit and refine existing images'), h3('turn visual output into reviewed assets'),
-  h2('handoffs preserve state and authority'), h3('name the repository state'), h3('return with evidence and the remaining decision'),
-];
-
-const workflowsClaude = [
-  h2('the everyday loop'), h3('scope the pass before the prompt'), h3('keep evidence close to the work'),
-  h2('parallel work needs visible boundaries'), h3('subagents protect the main context'), h3('background agents keep work moving'), h3('worktrees separate change ownership'),
-  h2('dynamic workflows coordinate more than one step'), h3('agent view makes parallel work visible'), h3('batch work needs independent units'), h3('repeatable loops need explicit routing'),
-  h2('work that continues without you'), h3('loop watches the current session'), h3('desktop scheduled tasks stay local'), h3('routines continue in the cloud'),
-  h2('working across devices'), h3('Remote Control keeps execution local'), h3('Dispatch starts work from mobile'), h3('web moves execution to the cloud'), h3('teleport changes the steering surface'),
-  h2('handoffs preserve state and authority'), h3('resume, branch, and teleport carry different state'), h3('return with evidence and the remaining decision'),
-];
-
-const extensionsCodex = [
-  h2('make operating knowledge reusable'), h3('instructions route the repository context'), h3('skills carry procedures, scripts, and references'),
-  h2('connect a real system'), h3('MCP exposes tools and resources'), h3('authentication and reach stay explicit'),
-  h2('make events deterministic'), h3('hooks run code at defined moments'), h3('failure should remain visible'),
-  h2('give work its own context'), h3('subagents need a bounded problem'), h3('the return contract matters'),
-  h2('package behavior for reuse'), h3('plugins move related behavior together'), h3('portable behavior needs an owner and version'),
-  h2('compose without losing the plot'), h3('route context instead of preloading it'), h3('every layer needs one clear job'), h3('maintenance cost is part of the design'),
-];
-
-const extensionsClaude = [
-  h2('make repository context durable'), h3('CLAUDE.md and rules establish context'), h3('skills carry procedures'), h3('imports keep shared knowledge singular'),
-  h2('connect a real system'), h3('MCP exposes tools and resources'), h3('authentication and reach stay explicit'),
-  h2('make events deterministic'), h3('hooks run code at defined moments'), h3('failure should remain visible'),
-  h2('give work its own context'), h3('subagents need a bounded problem'), h3('the return contract matters'),
-  h2('package behavior for reuse'), h3('plugins move related behavior together'), h3('portable behavior needs an owner and version'),
-  h2('compose without losing the plot'), h3('precedence decides which layer wins'), h3('context cost is part of the design'), h3('ownership makes removal possible'),
-];
-
-const safety = (providerSection, providerHeadings) => [
-  h2('access should match the job'), h3('filesystem, network, and external systems are separate kinds of reach'), h3('remote and cloud execution change the reachable world'),
-  h2('identity travels with the action'), h3('name the human, machine, and service identity'), h3('scoped identities fit unattended work'),
-  h2('unattended work changes the risk'), h3('scheduled work needs predeclared boundaries'), h3('event triggered work needs a narrow reachable world'),
-  h2('external actions need their own decision'), h3('preparing and executing are separate states'), h3('final authority belongs to the named human'), h3('merge, publish, deploy, send, pay, purchase, delete, and account changes return to the human'),
-  h2(providerSection), ...providerHeadings.map(h3),
-  h2('finish with authority clear'), h3('name what happened under which identity'), h3('return the remaining decision'),
-];
-
-const recommendationsCodex = [
-  h2('my default codex setup'), h3('desktop is the coordination hub'), h3('CLI and mobile have clear supporting jobs'),
-  h2('when i switch surfaces'), h3('the review surface follows the evidence'), h3('execution location is a separate decision'),
-  h2('what codex does unusually well'), h3('projectless work broadens the starting point'), h3('visible orchestration makes parallel work easier to judge'),
-  h2('where image generation earns its place'), h3('generate visual direction from project context'), h3('edit and refine existing images'), h3('turn visual experiments into reviewed assets'),
-  h2('why i recommend one password'), h3('the full access model belongs across agents'),
-  h2('what i would avoid'), h3('parallelism that outruns review'), h3('standing access without a bounded job'),
-  h2('what changed my mind'), h3('worktrees replaced direct main work'), h3('scoped authority replaced blanket autonomy'),
-  h2('how i use a paid plan'), h3('treat the week as a resource budget'),
-  h2('what i am still watching'), h3('mobile and remote execution keep changing'), h3('security and model behavior need dated claims'),
-];
-
-const recommendationsClaude = [
-  h2('my default claude code setup'), h3('terminal and repository context are my default'), h3('desktop and remote surfaces have clear supporting jobs'),
-  h2('when i switch surfaces'), h3('the review surface follows the evidence'), h3('execution location is a separate decision'),
-  h2('what claude code does unusually well'), h3('repository context compounds across real work'), h3('dynamic workflows can coordinate real operations'),
-  h2('when dynamic workflows earn their complexity'), h3('use them when they simplify a multistep job'), h3('background work needs a visible owner'), h3('routines need stable boundaries'),
-  h2('why i recommend one password'), h3('the full access model belongs across agents'),
-  h2('what i would avoid'), h3('context that grows without an owner'), h3('automation before a pass condition'),
-  h2('what changed my mind'), h3('provider roles are a lens rather than a rule'), h3('scoped authority replaced blanket autonomy'),
-  h2('how i use a paid plan'), h3('treat the week as a resource budget'),
-  h2('what i am still watching'), h3('mobile and Remote Control keep changing'), h3('current workflow features need a paired field run'),
-];
-
-const credentials = [
-  h2('credentials belong in an access layer'), h3('scope access to the current job'), h3('the broker supplies access while the secret stays encrypted'),
-  h2('interactive access keeps the human close'), h3('biometric approval is fast enough to use'), h3('browser access should be scoped per task'),
-  h2('automation needs a machine identity'), h3('service accounts narrow vault access'), h3('CLI, Environments, and Connect solve different jobs'),
-  h2('why i pay for one password'), h3('one access layer keeps machines and agents cleaner'), h3('the value grows with a dedicated host'),
-  h2('what changed my mind'), h3('the model expanded beyond CLI and Connect'), h3('provider integrations made scoped access practical'),
-  h2('what i am still testing'), h3('integration limits need current verification'),
-];
-
-const contracts = new Map([
-  ['docs/guides/codex.md', overviewCodex],
-  ['docs/guides/claude-code.md', overviewClaude],
-  ['docs/guides/codex/getting-started.md', gettingStarted('AGENTS.md explains the repository')],
-  ['docs/guides/claude-code/getting-started.md', gettingStarted('CLAUDE.md explains the repository')],
-  ['docs/guides/codex/configuration.md', configurationCodex],
-  ['docs/guides/claude-code/configuration.md', configurationClaude],
-  ['docs/guides/codex/workflows.md', workflowsCodex],
-  ['docs/guides/claude-code/workflows.md', workflowsClaude],
-  ['docs/guides/codex/extensions.md', extensionsCodex],
-  ['docs/guides/claude-code/extensions.md', extensionsClaude],
-  ['docs/guides/codex/safety.md', safety('security review is its own workflow', ['Codex Security surfaces hypotheses', 'a finding still needs validation'])],
-  ['docs/guides/claude-code/safety.md', safety('policy can set an organization floor', ['managed policy defines the floor', 'hooks can enforce specific events'])],
-  ['docs/guides/codex/recommendations.md', recommendationsCodex],
-  ['docs/guides/claude-code/recommendations.md', recommendationsClaude],
-  ['docs/guides/credentials-and-access.md', credentials],
-]);
-
+const blueprint = JSON.parse(await readFile(path.join(root, 'editorial/handbook-blueprints.json'), 'utf8'));
+const sourceRegistry = JSON.parse(await readFile(path.join(root, 'docs/sources.json'), 'utf8'));
+const sourceIds = new Set(sourceRegistry.sources.map((source) => source.id));
 const failures = [];
-for (const [relative, expected] of contracts) {
-  const markdown = await readFile(path.join(root, relative), 'utf8');
-  const actual = [...markdown.matchAll(/^(##|###) (.+)$/gm)].map((match) => `${match[1]} ${match[2]}`);
-  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-    failures.push(`${relative}: heading contract changed\nexpected: ${JSON.stringify(expected)}\nactual:   ${JSON.stringify(actual)}`);
+
+function scalar(markdown, key) {
+  return markdown.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '';
+}
+
+function headings(markdown) {
+  return [...markdown.matchAll(/^(##|###) (.+)$/gm)].map((match) => `${match[1]} ${match[2]}`);
+}
+
+function isOrderedSubset(actual, expected) {
+  let cursor = 0;
+  for (const heading of actual) {
+    cursor = expected.indexOf(heading, cursor);
+    if (cursor === -1) return false;
+    cursor += 1;
   }
-  if (!/^checkedAt:\s*"\d{4}-\d{2}-\d{2}T[^\n]+"$/m.test(markdown)) failures.push(`${relative}: checkedAt is required`);
+  return true;
+}
+
+function anchorFor(heading) {
+  return heading
+    .replace(/^###?\s+/, '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[’']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+for (const guide of blueprint.guides) {
+  const relative = guide.file;
+  const markdown = await readFile(path.join(root, relative), 'utf8');
+  const expected = guide.headings;
+  const actual = headings(markdown);
+  const completion = scalar(markdown, 'completion');
+  const draft = scalar(markdown, 'draft') === 'true';
+  const status = scalar(markdown, 'status');
+
+  if (!['outline', 'excerpt', 'complete'].includes(completion)) {
+    failures.push(`${relative}: completion must be outline, excerpt, or complete`);
+    continue;
+  }
+
+  if (completion === 'excerpt') {
+    if (!isOrderedSubset(actual, expected)) failures.push(`${relative}: excerpt headings are not an ordered subset of the blueprint`);
+  } else if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    failures.push(`${relative}: ${completion} headings do not match the blueprint`);
+  }
+
+  if (completion === 'outline' && (!draft || status !== 'pending')) {
+    failures.push(`${relative}: outline pages must be draft and pending`);
+  }
+  if (completion !== 'outline' && (draft || status !== 'current')) {
+    failures.push(`${relative}: public excerpt and complete pages must be non-draft and current`);
+  }
+  if (!/^checkedAt:\s*"\d{4}-\d{2}-\d{2}T[^\n]+"$/m.test(markdown)) {
+    failures.push(`${relative}: checkedAt is required`);
+  }
+
+  const anchors = actual.map(anchorFor);
+  const duplicateAnchors = anchors.filter((anchor, index) => anchors.indexOf(anchor) !== index);
+  if (duplicateAnchors.length) failures.push(`${relative}: duplicate heading anchors: ${[...new Set(duplicateAnchors)].join(', ')}`);
+
+  if (!guide.provider || !guide.chapter || !guide.evidenceType) failures.push(`${relative}: blueprint metadata is incomplete`);
+  if (!Array.isArray(guide.experienceQuestions) || !guide.experienceQuestions.length) failures.push(`${relative}: blueprint experience questions are required`);
+  for (const sourceId of guide.sourceIds ?? []) {
+    if (!sourceIds.has(sourceId)) failures.push(`${relative}: blueprint source ${sourceId} is absent from docs/sources.json`);
+  }
 }
 
 if (failures.length) {
@@ -159,4 +82,4 @@ if (failures.length) {
   process.exit(1);
 }
 
-console.log(`validated handbook heading and freshness contracts for ${contracts.size} guides`);
+console.log(`validated handbook publication contracts for ${blueprint.guides.length} guides`);

--- a/scripts/test-navigation.mjs
+++ b/scripts/test-navigation.mjs
@@ -85,6 +85,28 @@ try {
   expect(Math.abs(mobileHeaderGeometry.tabCenterDelta) <= .5, `mobile provider tabs are not centered as a group: ${mobileHeaderGeometry.tabCenterDelta}`);
   expect(mobileHeaderGeometry.controlSizes.every(({ width, height }) => width === 36 && height === 36), `mobile header controls do not share one 36px geometry: ${JSON.stringify(mobileHeaderGeometry.controlSizes)}`);
   expect(mobileHeaderGeometry.actionRailHeight === 44, `mobile header utility rail is not a compact 44px group: ${mobileHeaderGeometry.actionRailHeight}`);
+  const mobileScrollContract = await page.evaluate(() => ({
+    rootOverscroll: getComputedStyle(document.documentElement).overscrollBehaviorY,
+    bodyOverscroll: getComputedStyle(document.body).overscrollBehaviorY,
+    horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  }));
+  expect(mobileScrollContract.rootOverscroll === 'none' && mobileScrollContract.bodyOverscroll === 'none', `mobile page retains rubber-band overscroll: ${JSON.stringify(mobileScrollContract)}`);
+  expect(mobileScrollContract.horizontalOverflow === 0, `mobile page has horizontal overflow: ${mobileScrollContract.horizontalOverflow}`);
+  await page.locator('.search-trigger').click();
+  const mobileSearchDialog = page.locator('.search-access site-search dialog');
+  await mobileSearchDialog.waitFor({ state: 'visible' });
+  const mobileSearchGeometry = await mobileSearchDialog.evaluate((dialog) => {
+    const box = dialog.getBoundingClientRect();
+    return { x: box.x, y: box.y, width: box.width, height: box.height, viewportWidth: innerWidth, viewportHeight: innerHeight };
+  });
+  expect(mobileSearchGeometry.x === 0 && mobileSearchGeometry.y === 0 && mobileSearchGeometry.width === mobileSearchGeometry.viewportWidth && mobileSearchGeometry.height === mobileSearchGeometry.viewportHeight, `mobile search is not a full-viewport surface: ${JSON.stringify(mobileSearchGeometry)}`);
+  const mobileSearchInput = mobileSearchDialog.locator('input[type="text"], input[type="search"]').first();
+  await mobileSearchInput.waitFor({ state: 'visible' });
+  await mobileSearchInput.fill('codex');
+  await mobileSearchDialog.locator('.pagefind-ui__result').first().waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+  expect(await mobileSearchDialog.locator('.pagefind-ui__result').count() > 0, 'mobile search does not return indexed results');
+  await mobileSearchDialog.locator('[data-close-modal]').click();
+  expect(await mobileSearchDialog.getAttribute('open') === null, 'mobile search close control does not dismiss the dialog');
   const initialTheme = await page.locator('html').getAttribute('data-theme');
   const themeButton = page.locator('.theme-control');
   await themeButton.click();
@@ -358,17 +380,34 @@ try {
   expect(tabletStart.mobileToc?.visible && tabletStart.mobileToc.x === 68 && tabletStart.mobileToc.width === 700, '768px reading path does not account for the compact chapter rail');
   expect(!tabletStart.rightRail?.visible && !tabletStart.rightToggle?.visible, '768px tablet layout exposes the desktop reading rail');
 
+  const reloadContext = await browser.newContext({ viewport: { width: 768, height: 900 } });
+  await reloadContext.addInitScript(() => localStorage.setItem('coding-agent-tips:reading-rails', 'collapsed'));
+  const reloadPage = await reloadContext.newPage();
+  await reloadPage.goto(`${origin}/guides/codex/`, { waitUntil: 'domcontentloaded' });
+  const railAtFirstDocumentPaint = await reloadPage.locator('.sidebar-pane').evaluate((sidebar) => ({
+    width: sidebar.getBoundingClientRect().width,
+    runningWidthAnimations: sidebar.getAnimations().filter((animation) => animation.playState === 'running').length,
+    state: document.documentElement.dataset.leftRail,
+  }));
+  await reloadPage.waitForTimeout(220);
+  const railAfterHydration = await reloadPage.locator('.sidebar-pane').evaluate((sidebar) => sidebar.getBoundingClientRect().width);
+  expect(railAtFirstDocumentPaint.state === 'collapsed' && railAtFirstDocumentPaint.width === 68 && railAtFirstDocumentPaint.runningWidthAnimations === 0, `tablet rail state was not established before first paint: ${JSON.stringify(railAtFirstDocumentPaint)}`);
+  expect(railAfterHydration === railAtFirstDocumentPaint.width, `tablet rail flashes from expanded to collapsed on reload: ${railAtFirstDocumentPaint.width} -> ${railAfterHydration}`);
+  await reloadContext.close();
+
   const tabletMainBefore = tabletStart.main;
   await responsivePage.locator('[data-rail-toggle="left"]').click();
   await responsivePage.waitForTimeout(220);
   const tabletExpanded = await geometry();
   expect(tabletExpanded.sidebar?.width === 272, 'tablet chapter rail does not expand');
   expect(tabletExpanded.main?.x === tabletMainBefore?.x && tabletExpanded.main?.width === tabletMainBefore?.width, 'tablet chapter rail pushes or resizes the article instead of overlaying it');
-  expect(tabletExpanded.mobileToc?.x === 68 && tabletExpanded.mobileToc?.width === 700, 'overlay tablet reading path does not retain the compact rail inset');
+  expect(!tabletExpanded.mobileToc?.visible, 'overlay tablet reading path remains layered over the open chapter drawer');
   expect(await responsivePage.locator('.rail-scrim').evaluate((scrim) => getComputedStyle(scrim).pointerEvents === 'auto'), 'overlay tablet rail does not expose its dismissing scrim');
   await responsivePage.keyboard.press('Escape');
   await responsivePage.waitForTimeout(220);
-  expect((await geometry()).sidebar?.width === 68, 'Escape does not collapse the tablet chapter rail');
+  const tabletClosed = await geometry();
+  expect(tabletClosed.sidebar?.width === 68, 'Escape does not collapse the tablet chapter rail');
+  expect(tabletClosed.mobileToc?.visible && tabletClosed.mobileToc.x === 68 && tabletClosed.mobileToc.width === 700, 'tablet reading path does not return to the compact rail inset after closing the drawer');
   expect(await responsivePage.locator('[data-rail-toggle="left"]').evaluate((button) => document.activeElement === button), 'Escape does not return focus to the tablet rail control');
 
   await responsivePage.setViewportSize({ width: 896, height: 800 });

--- a/src/components/RailHead.astro
+++ b/src/components/RailHead.astro
@@ -1,0 +1,20 @@
+<script is:inline>
+  (() => {
+    const storageKey = 'coding-agent-tips:reading-rails';
+    const paired = matchMedia('(min-width: 80rem)').matches;
+    const overlay = matchMedia('(min-width: 48rem) and (max-width: 55.99rem)').matches;
+    let stored = null;
+    try { stored = localStorage.getItem(storageKey); } catch {}
+
+    const state = overlay
+      ? 'collapsed'
+      : stored === 'expanded' || stored === 'collapsed'
+        ? stored
+        : paired ? 'expanded' : 'collapsed';
+
+    document.documentElement.dataset.leftRail = state;
+    document.documentElement.dataset.rightRail = paired ? state : 'collapsed';
+    document.documentElement.dataset.drawerState = 'closed';
+    document.documentElement.dataset.railStateReady = '';
+  })();
+</script>

--- a/src/components/SearchAccess.astro
+++ b/src/components/SearchAccess.astro
@@ -2,7 +2,7 @@
 import Search from '@astrojs/starlight/components/Search.astro';
 ---
 
-<div class="search-access"><Search /></div>
+<div class="search-access" transition:persist="site-search"><Search /></div>
 
 <script>
   declare global {
@@ -34,22 +34,20 @@ import Search from '@astrojs/starlight/components/Search.astro';
 
 <style>
   .search-access {
-    position: absolute;
-    inline-size: 1px;
-    block-size: 1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    contain: inline-size;
+    position: fixed;
+    z-index: var(--z-menu);
+    inset: 0 auto auto 0;
+    inline-size: 0;
+    block-size: 0;
+    overflow: visible;
+    pointer-events: none;
   }
 
-  .search-access:focus-within {
-    inset-inline-end: 1rem;
-    inset-block-start: 0.6rem;
-    inline-size: min(24rem, calc(100vw - 2rem));
-    block-size: auto;
-    clip-path: none;
-    overflow: visible;
-    contain: none;
-    z-index: var(--z-menu);
+  .search-access :global(site-search > button[data-open-modal]) {
+    display: none !important;
+  }
+
+  .search-access :global(dialog) {
+    pointer-events: auto;
   }
 </style>

--- a/src/components/StarlightHead.astro
+++ b/src/components/StarlightHead.astro
@@ -3,9 +3,11 @@ import DefaultHead from '@astrojs/starlight/components/Head.astro';
 import { ClientRouter } from 'astro:transitions';
 import globalStyles from '../styles/global.css?inline';
 import ThemeHead from './ThemeHead.astro';
+import RailHead from './RailHead.astro';
 ---
 
 <DefaultHead />
 <ThemeHead />
+<RailHead />
 <style is:inline transition:persist="site-styles" set:html={globalStyles}></style>
 <ClientRouter fallback="swap" />

--- a/src/components/StarlightMarkdownContent.astro
+++ b/src/components/StarlightMarkdownContent.astro
@@ -1,0 +1,15 @@
+---
+import DefaultMarkdownContent from '@astrojs/starlight/components/MarkdownContent.astro';
+
+const entry = Astro.locals.starlightRoute.entry;
+const isOutline = entry.data.completion === 'outline';
+---
+
+<DefaultMarkdownContent>
+  {isOutline ? (
+    <div class="outline-review-state" role="status">
+      <p><strong>this chapter is still in the editorial blueprint.</strong></p>
+      <p>its section structure stays out of the reader preview until the paired Codex and Claude Code chapter has substantive copy ready for review.</p>
+    </div>
+  ) : <slot />}
+</DefaultMarkdownContent>

--- a/src/components/StarlightPageSidebar.astro
+++ b/src/components/StarlightPageSidebar.astro
@@ -5,14 +5,15 @@ type TocNode = { depth: number; slug: string; text: string; children: TocNode[] 
 type RailHeading = { depth: number; slug: string; text: string };
 
 const { toc } = Astro.locals.starlightRoute;
+const isOutline = Astro.locals.starlightRoute.entry.data.completion === 'outline';
 const flattenHeadings = (items: TocNode[]): RailHeading[] => items.flatMap((item) => [
   { depth: item.depth, slug: item.slug, text: item.text },
   ...flattenHeadings(item.children),
 ]);
-const headings = toc ? flattenHeadings(toc.items as TocNode[]).filter((item) => item.slug !== '_top' && item.depth <= 3) : [];
+const headings = toc && !isOutline ? flattenHeadings(toc.items as TocNode[]).filter((item) => item.slug !== '_top' && item.depth <= 3) : [];
 ---
 
-{toc && (
+{headings.length > 0 && (
   <>
     <nav class="handbook-mobile-toc lg:sl-hidden" aria-label="on this page">
       <details data-mobile-reading-path data-animated-disclosure>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,7 @@ const sourceId = z.string().refine((id) => sourceIds.has(id), 'source identifier
 const evidenceStatus = z.enum(['tested', 'official-source', 'analysis', 'open-question']);
 const navigationScope = z.enum(['general', 'codex', 'claude-code', 'grok', 'opencode', 'qwen-code', 'kimi-code', 'aider']);
 const voice = z.enum(['personal', 'evidence', 'documentary', 'frozen']);
+const completion = z.enum(['outline', 'excerpt', 'complete']);
 const navigation = z.object({
   scope: navigationScope,
   order: z.number().int().nonnegative(),
@@ -23,6 +24,7 @@ const common = {
   sources: z.array(sourceId),
   redirects: z.array(z.string()).default([]),
   voice,
+  completion: completion.optional(),
   navigation,
 };
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -6,7 +6,7 @@ export type HandbookEntry = CollectionEntry<'docs'>;
 export const routeForEntry = (entry: HandbookEntry) => `/${entry.id.replace(/\/$/, '')}/`;
 
 export async function getHandbookPages(options: { includeHidden?: boolean; includeArchive?: boolean; includeDrafts?: boolean; scope?: NavigationScope } = {}) {
-  const { includeHidden = false, includeArchive = true, includeDrafts = !import.meta.env.PROD, scope } = options;
+  const { includeHidden = false, includeArchive = true, includeDrafts = false, scope } = options;
   const scopeOrder = new Map(handbookScopes.map((item) => [item.id, item.order]));
   const entries = await getCollection('docs');
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,7 +22,7 @@ const socialImage = new URL(site.socialImage, Astro.site);
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />

--- a/src/pages-dev/copy-review.astro
+++ b/src/pages-dev/copy-review.astro
@@ -11,7 +11,7 @@ import { navigationScopes, site } from '../site';
 const root = process.cwd();
 const home = await getEntry('home', 'home');
 if (!home) throw new Error('content/home.md is required');
-const pages = await getHandbookPages({ includeArchive: true });
+const pages = await getHandbookPages({ includeArchive: true, includeDrafts: true });
 const runs = (await getCollection('runs')).sort((left, right) => right.data.date.valueOf() - left.data.date.valueOf());
 const surfaces = [
   { route: '/', owner: 'content/home.md', title: home.data.title, description: home.data.description, voice: home.data.voice },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,8 +96,19 @@ html[data-theme='dark'] {
 ::view-transition-new(root) { animation: none; }
 
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; background: var(--white); color: var(--ink); }
-body { margin: 0; background: var(--white); color: var(--ink); }
+html {
+  scroll-behavior: smooth;
+  overscroll-behavior-y: none;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--slate) 52%, transparent) transparent;
+  background: var(--white);
+  color: var(--ink);
+}
+body { min-block-size: 100%; margin: 0; overflow-x: clip; overscroll-behavior-y: none; background: var(--white); color: var(--ink); }
+html::-webkit-scrollbar { inline-size: 6px; block-size: 6px; }
+html::-webkit-scrollbar-track { background: transparent; }
+html::-webkit-scrollbar-thumb { border: 1px solid transparent; border-radius: var(--radius-pill); background: color-mix(in srgb, var(--slate) 52%, transparent); background-clip: padding-box; }
+html::-webkit-scrollbar-thumb:hover { background: color-mix(in srgb, var(--cobalt) 72%, var(--slate)); background-clip: padding-box; }
 a { color: inherit; }
 a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px solid var(--cobalt); outline-offset: 3px; }
 .skip-link { position: fixed; inset: 0 auto auto 0; z-index: var(--z-emergency); padding: .65rem 1rem; background: var(--ink); color: var(--white); transform: translateY(-120%); }
@@ -132,6 +143,33 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .search-trigger:hover, .search-trigger:focus-visible { border-color: color-mix(in srgb, var(--cobalt) 58%, var(--rule)); }
 .search-trigger svg { inline-size: 1rem; block-size: 1rem; }
 .search-trigger kbd { margin-inline-start: auto; padding: .12rem .32rem; border: 1px solid var(--rule); border-radius: var(--radius-sm); background: var(--surface-raised); color: var(--slate); }
+.search-access site-search dialog {
+  z-index: var(--z-preview);
+  border-color: var(--rule);
+  background: var(--surface-raised);
+  color: var(--ink);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, .22);
+}
+.search-access site-search dialog::backdrop { background: color-mix(in srgb, var(--surface-canvas) 28%, rgba(5, 7, 12, .72)); backdrop-filter: blur(8px); }
+.search-access site-search .dialog-frame { overscroll-behavior: contain; scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--slate) 52%, transparent) transparent; }
+.search-access #starlight__search {
+  --pagefind-ui-primary: var(--cobalt);
+  --pagefind-ui-text: var(--ink);
+  --pagefind-ui-background: var(--surface-raised);
+  --pagefind-ui-border: var(--rule);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: var(--radius-md);
+  --pagefind-ui-font: 'Instrument Sans', system-ui, sans-serif;
+}
+.search-access #starlight__search .pagefind-ui__search-input { min-block-size: 3.15rem; border-radius: var(--radius-md); background: var(--surface-subtle); color: var(--ink); }
+.search-access #starlight__search .pagefind-ui__search-input:focus { border-color: var(--cobalt); box-shadow: 0 0 0 3px var(--accent-soft); }
+.search-access #starlight__search .pagefind-ui__result { padding-block: 1rem; border-top-color: var(--rule); }
+.search-access #starlight__search .pagefind-ui__result-link { color: var(--ink); text-decoration: none; }
+.search-access #starlight__search .pagefind-ui__result-link:hover { color: var(--cobalt); }
+.search-access #starlight__search mark { border-radius: .18rem; background: var(--accent-soft); color: var(--accent-strong); }
+.outline-review-state { max-width: 42rem; padding: 1rem 1.1rem; border: 1px solid var(--rule); border-radius: var(--radius-md); background: var(--surface-subtle); }
+.outline-review-state p { margin: 0; }
+.outline-review-state p + p { margin-top: .45rem; color: var(--slate); }
 .theme-control { inline-size: 2.25rem; display: grid; place-items: center; padding: 0; background: transparent; color: var(--slate); cursor: pointer; }
 .theme-control svg { grid-area: 1 / 1; inline-size: 1.05rem; block-size: 1.05rem; display: none; }
 .theme-control[data-theme-resolved='light'] .theme-light-icon,
@@ -194,6 +232,10 @@ header.header { z-index: var(--z-navigation); height: var(--site-header-height);
   scrollbar-gutter: auto;
   transition: width var(--motion-ui-duration) var(--motion-ui-ease), box-shadow var(--motion-ui-duration) var(--motion-ui-ease);
 }
+html:not([data-rail-state-ready]) .sidebar-pane,
+html:not([data-rail-state-ready]) .right-sidebar-container,
+html:not([data-rail-state-ready]) .right-sidebar,
+html:not([data-rail-state-ready]) .main-frame { transition: none !important; }
 .sidebar-content { height: 100%; min-height: 0 !important; padding: 0 !important; }
 .sidebar-content::after { display: none !important; }
 .handbook-sidebar { position: relative; z-index: 1; min-height: 0; height: 100%; padding: 1rem .85rem; background: var(--surface-raised); }
@@ -500,10 +542,11 @@ html[data-right-rail='collapsed'] .reading-rail a::after { inset-inline-end: cal
   .search-trigger span, .search-trigger kbd { display: none; }
   html[data-left-rail='expanded'] { --left-rail-width: var(--rail-expanded-width); }
   html[data-left-rail='collapsed'] { --left-rail-width: var(--rail-collapsed-width); }
-  html[data-drawer-state='open'] .sidebar-pane { box-shadow: .75rem 0 2rem rgba(0, 0, 0, .18); }
+  html[data-drawer-state='open'] .sidebar-pane { z-index: calc(var(--z-navigation) + 2); box-shadow: .75rem 0 2rem rgba(0, 0, 0, .18); }
   .rail-scrim { position: fixed; z-index: 0; inset: var(--site-header-height) 0 0; inline-size: 100vw; block-size: calc(100vh - var(--site-header-height)); padding: 0; border: 0; background: rgba(7, 9, 14, .38); opacity: 0; pointer-events: none; transition: opacity var(--motion-ui-duration) var(--motion-ui-ease); }
   html[data-drawer-state='open'] .rail-scrim { display: block; opacity: 1; pointer-events: auto; }
   html[data-drawer-state='open'] .handbook-sidebar { position: relative; z-index: 1; }
+  html[data-drawer-state='open'] .handbook-mobile-toc { visibility: hidden; opacity: 0; pointer-events: none; }
   body.chapter-drawer-open { overflow: hidden; }
   .right-sidebar-container { display: block !important; flex: 0 0 0 !important; width: 0 !important; }
   .right-sidebar { width: 0 !important; border-inline-start: 0 !important; }
@@ -571,6 +614,28 @@ html[data-right-rail='collapsed'] .reading-rail a::after { inset-inline-end: cal
   .mobile-site-menu footer { margin-top: .45rem; padding-top: .45rem; border-top: 1px solid var(--rule); }
   .mobile-site-menu footer a { display: flex; align-items: center; gap: .55rem; }
   .mobile-site-menu footer svg { inline-size: 1rem; block-size: 1rem; }
+  .search-access site-search dialog {
+    inset: 0;
+    inline-size: 100dvw;
+    block-size: 100dvh;
+    max-inline-size: none;
+    max-block-size: none;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+  .search-access site-search .dialog-frame {
+    min-block-size: 100%;
+    padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) max(1rem, env(safe-area-inset-bottom)) max(1rem, env(safe-area-inset-left));
+  }
+  .search-access site-search button[data-close-modal] {
+    inset: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) auto auto;
+    min-block-size: 3.15rem;
+    padding-inline: .7rem;
+    border-radius: var(--radius-md);
+    color: var(--cobalt);
+  }
+  .search-access #starlight__search { --sl-search-cancel-space: 4.5rem; }
 }
 
 @media (max-width: 79.99rem) {
@@ -584,7 +649,8 @@ html[data-right-rail='collapsed'] .reading-rail a::after { inset-inline-end: cal
     border-bottom: 1px solid var(--rule);
     background: color-mix(in srgb, var(--surface-raised) 96%, transparent);
     backdrop-filter: blur(12px);
-    transition: inset-inline-start var(--motion-ui-duration) var(--motion-ui-ease);
+    opacity: 1;
+    transition: inset-inline-start var(--motion-ui-duration) var(--motion-ui-ease), opacity 100ms linear;
   }
   .handbook-mobile-toc details { position: relative; }
   .handbook-mobile-toc summary {
@@ -609,7 +675,8 @@ html[data-right-rail='collapsed'] .reading-rail a::after { inset-inline-end: cal
 }
 
 @media (max-width: 47.99rem) {
-  html { scroll-behavior: auto; }
+  html { scroll-behavior: auto; scrollbar-width: thin; }
+  html::-webkit-scrollbar { inline-size: 3px; block-size: 3px; }
   .site-header { min-height: var(--site-header-height); }
   .home-content { padding-top: 3.5rem; }
   .home-guides { padding-top: 3rem; }


### PR DESCRIPTION
## Summary

- move the full paired handbook hierarchy into an editorial blueprint and keep unfinished chapters out of public surfaces
- add outline, excerpt, and complete publication contracts with substantive-heading validation
- complete the paired overview checkpoint without replacing approved prose
- stabilize first-paint rail state, tablet layering, mobile search, and overscroll behavior

## Verification

- bun run check:content
- bun run build
- bun run test:site
- bun run test:navigation
- bun run test:a11y
- bun run check:performance

This PR intentionally stops before the new guide-navigation redesign. That work will start from the merged main tree in a separate design worktree.