### PR TITLE
fix(ui): unify guide theme and sidebar chrome

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig({
         MarkdownContent: './src/components/StarlightMarkdownContent.astro',
         Footer: './src/components/StarlightFooter.astro',
         Sidebar: './src/components/StarlightSidebar.astro',
+        ThemeProvider: './src/components/StarlightThemeProvider.astro',
       },
       social: [{ icon: 'github', label: 'GitHub', href: repository }],
       lastUpdated: false,

--- a/scripts/check-ui-ownership.mjs
+++ b/scripts/check-ui-ownership.mjs
@@ -64,6 +64,7 @@ const allowedControllers = new Set([
   'src/components/PublicationEnhancements.astro',
   'src/components/StarlightPageSidebar.astro',
   'src/components/StarlightPageTitle.astro',
+  'src/components/StarlightThemeProvider.astro',
   'src/components/ThemeBridge.astro',
 ]);
 for (const [file, source] of repositoryText) {

--- a/scripts/test-navigation.mjs
+++ b/scripts/test-navigation.mjs
@@ -147,6 +147,58 @@ try {
 
   const sidebar = page.locator('.publication-sidebar-provider');
   const sidebarTrigger = sidebar.locator('[data-sw-sidebar-trigger]').first();
+  const chromeStyles = await page.evaluate(() => {
+    const box = (selector) => {
+      const element = document.querySelector(selector);
+      const styles = getComputedStyle(element);
+      const bounds = element.getBoundingClientRect();
+      return {
+        borderStyle: styles.borderStyle,
+        height: bounds.height,
+        width: bounds.width,
+      };
+    };
+    const siteMark = document.querySelector('.site-name img').getBoundingClientRect();
+    const railMark = document.querySelector('.sidebar-provider-icon').getBoundingClientRect();
+    return {
+      controls: [
+        box('[data-slot="theme-toggle"]'),
+        box('.github-link'),
+        box('[data-sw-sidebar-trigger]'),
+      ],
+      listMarkers: [...document.querySelectorAll('.publication-sidebar li')]
+        .filter((item) => getComputedStyle(item).listStyleType !== 'none').length,
+      outlineRule: getComputedStyle(document.querySelector('.sidebar-page-outline')).borderInlineStartWidth,
+      railHeaderHeight: document.querySelector('.handbook-rail-head').getBoundingClientRect().height,
+      siteHeaderHeight: document.querySelector('.site-header').getBoundingClientRect().height,
+      leftAlignmentDelta: Math.abs(siteMark.left - railMark.left),
+    };
+  });
+  expect(chromeStyles.controls.every((control) => control.width === 36 && control.height === 36), 'header and sidebar controls do not share a 36px footprint');
+  expect(chromeStyles.controls.every((control) => control.borderStyle !== 'outset'), 'native browser borders leak into Starwind controls');
+  expect(chromeStyles.listMarkers === 0, 'browser list markers leak into the guide sidebar');
+  expect(chromeStyles.outlineRule === '0px', 'the retired heading connector rule remains visible');
+  expect(chromeStyles.railHeaderHeight === chromeStyles.siteHeaderHeight, 'sidebar and site headers use different vertical rhythms');
+  expect(chromeStyles.leftAlignmentDelta < 1, 'sidebar identity does not align with the site header gutter');
+
+  await page.locator('[data-slot="theme-toggle"]').click();
+  const darkChrome = await page.evaluate(() => {
+    const probe = document.createElement('span');
+    probe.style.color = 'var(--surface-subtle)';
+    document.body.append(probe);
+    const surfaceSubtle = getComputedStyle(probe).color;
+    probe.remove();
+    return {
+      kbdBackground: getComputedStyle(document.querySelector('.header-search kbd')).backgroundColor,
+      surfaceSubtle,
+      sidebarBackground: getComputedStyle(document.querySelector('.publication-sidebar [data-slot="sidebar-inner"]')).backgroundColor,
+      canvasBackground: getComputedStyle(document.body).backgroundColor,
+    };
+  });
+  expect(darkChrome.kbdBackground === darkChrome.surfaceSubtle, 'dark search shortcut does not use the dark subtle surface');
+  expect(darkChrome.sidebarBackground === darkChrome.canvasBackground, 'dark sidebar uses a mismatched surface color');
+  await page.locator('[data-slot="theme-toggle"]').click();
+
   expect(await sidebar.getAttribute('data-state') === 'expanded', 'desktop sidebar is not expanded initially');
   await sidebarTrigger.click();
   expect(await sidebar.getAttribute('data-state') === 'collapsed', 'desktop sidebar did not collapse');
@@ -159,6 +211,7 @@ try {
   await page.locator('[aria-label="codex handbook chapters"] a[href="/guides/codex/configuration/"]').click();
   await page.waitForURL('**/guides/codex/configuration/');
   expect(desktopDocumentToken === await page.evaluate(() => window.__navigationDocumentToken), 'chapter navigation caused a full reload');
+  expect(await page.locator('html').evaluate((root) => root.classList.contains('dark') === (root.dataset.theme === 'dark')), 'Starwind and Starlight theme state diverged after chapter navigation');
   expect((await page.locator('[aria-label="codex handbook chapters"] [aria-current="page"]').textContent())?.trim() === 'configuration', 'sidebar active chapter did not update');
   await page.goBack();
   await page.waitForURL('**/guides/codex/');

--- a/src/components/StarlightThemeProvider.astro
+++ b/src/components/StarlightThemeProvider.astro
@@ -1,0 +1,10 @@
+<!--
+  Starwind is the sole theme preference and interaction owner. Starlight still
+  expects this compatibility object to exist, but must not read a second
+  storage key or independently mutate data-theme.
+-->
+<script is:inline>
+  window.StarlightThemeProvider = {
+    updatePickers() {},
+  };
+</script>

--- a/src/styles/guide-navigation.css
+++ b/src/styles/guide-navigation.css
@@ -30,14 +30,15 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
   border: 0;
 }
 
-.publication-sidebar [data-slot='sidebar-inner'] { background: var(--surface-raised); }
+.publication-sidebar [data-slot='sidebar-inner'] { background: var(--surface-canvas); }
 .handbook-rail-head {
-  min-block-size: 3.25rem;
-  padding: .625rem .5rem .375rem;
+  min-block-size: var(--site-header-height);
+  padding: .75rem var(--site-gutter);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: .5rem;
+  border-bottom: 1px solid var(--rule);
 }
 
 .guide-rail-identity { min-inline-size: 0; display: flex; align-items: center; gap: .55rem; }
@@ -50,15 +51,44 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
   background: transparent;
 }
 
+.publication-sidebar [data-sw-sidebar-trigger] {
+  inline-size: 2.25rem;
+  min-inline-size: 2.25rem;
+  block-size: 2.25rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--slate);
+  box-shadow: none;
+}
+.publication-sidebar [data-sw-sidebar-trigger]:hover {
+  border-color: transparent;
+  background: var(--soft);
+  color: var(--ink);
+}
+.publication-sidebar [data-sw-sidebar-trigger]:focus-visible {
+  border-color: var(--cobalt);
+  background: var(--soft);
+  color: var(--ink);
+}
+.publication-sidebar [data-sw-sidebar-trigger] svg { inline-size: 1.125rem; block-size: 1.125rem; }
+
 .publication-sidebar-content {
   gap: 0;
-  padding: .125rem .5rem .875rem;
+  padding: .5rem .75rem .875rem;
   overflow-y: auto;
   scrollbar-width: none;
 }
 .publication-sidebar-content::-webkit-scrollbar { display: none; }
 
-.publication-sidebar [data-sidebar='menu'] { gap: .125rem; }
+.publication-sidebar :where(
+  [data-sidebar='menu'],
+  [data-sidebar='menu-sub'],
+  [data-slot='sidebar-menu-item'],
+  [data-slot='sidebar-menu-sub-item']
+) { list-style: none; }
+.publication-sidebar [data-sidebar='menu'] { gap: .125rem; margin: 0; padding: 0; }
 .publication-sidebar [data-sidebar='menu-button'] {
   min-block-size: 2rem;
   block-size: auto;
@@ -80,19 +110,19 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 .publication-sidebar [data-sidebar='menu-button'] > svg { inline-size: 1rem; block-size: 1rem; }
 
 .sidebar-page-outline {
-  margin: .125rem .125rem .375rem 1.45rem;
-  padding: .125rem 0;
-  border-inline-start: 1px solid var(--rule);
+  margin: .125rem 0 .375rem 1.5rem;
+  padding: 0;
+  border-inline-start: 0;
   transform: none;
 }
 .sidebar-page-outline [data-slot='sidebar-menu-sub-item'] {
-  padding-inline-start: calc(var(--heading-depth) * .65rem);
+  padding-inline-start: calc(var(--heading-depth) * .7rem);
 }
 .sidebar-page-outline [data-sidebar='menu-sub-button'] {
   min-block-size: 1.65rem;
   block-size: auto;
-  margin-inline-start: .3rem;
-  padding: .2rem .45rem;
+  margin-inline-start: 0;
+  padding: .2rem .5rem;
   border-radius: .3rem;
   color: var(--slate);
   white-space: normal;
@@ -105,7 +135,7 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 
 .publication-sidebar[data-state='collapsed'] .guide-rail-identity,
 .publication-sidebar[data-state='collapsed'] .sidebar-page-outline { display: none; }
-.publication-sidebar[data-state='collapsed'] .handbook-rail-head { justify-content: center; }
+.publication-sidebar[data-state='collapsed'] .handbook-rail-head { justify-content: center; padding-inline: 0; }
 .publication-sidebar[data-state='collapsed'] [data-sidebar='menu-button'] {
   inline-size: 2.5rem;
   min-block-size: 2.5rem;
@@ -119,7 +149,7 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
     width: var(--left-rail-width) !important;
     visibility: visible !important;
     overflow: hidden;
-    background: var(--surface-raised);
+    background: var(--surface-canvas);
     transition: width 200ms ease-linear;
   }
   nav.sidebar { display: block !important; scrollbar-width: none; }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -30,12 +30,32 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .header-actions { grid-column: 3; grid-row: 1; display: flex; align-items: center; justify-self: end; gap: .45rem; }
 .github-link { display: inline-flex; align-items: center; gap: .4rem; justify-self: end; color: var(--ink); }
 .github-link { text-decoration: none; }
-.github-link svg { inline-size: 1.35rem; block-size: 1.35rem; }
+.github-link svg,
+.site-header-control [data-theme-icon-wrapper],
+.site-header-control [data-theme-icon] { inline-size: 1.125rem; block-size: 1.125rem; }
 .header-search site-search > button,
 .site-header-control { min-block-size: 2.25rem; border-radius: var(--radius-md); }
+.site-header-control {
+  inline-size: 2.25rem;
+  min-inline-size: 2.25rem;
+  block-size: 2.25rem;
+  padding: 0;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--slate);
+  box-shadow: none;
+}
+.site-header-control:hover { border-color: transparent; background: var(--soft); color: var(--ink); }
+.site-header-control:focus-visible { border-color: var(--cobalt); background: var(--soft); color: var(--ink); }
 .header-search site-search > button { min-inline-size: 7.75rem; block-size: 2.25rem; border: 1px solid var(--rule); background: color-mix(in srgb, var(--surface-subtle) 58%, transparent); color: var(--slate); }
 .header-search site-search > button:hover,
 .header-search site-search > button:focus-visible { border-color: color-mix(in srgb, var(--cobalt) 58%, var(--rule)); background: var(--soft); color: var(--ink); }
+.header-search site-search > button kbd {
+  border: 1px solid var(--rule);
+  background: var(--surface-subtle);
+  color: var(--slate);
+  box-shadow: none;
+}
 .header-search site-search dialog {
   z-index: var(--z-preview);
   border-color: var(--rule);

--- a/src/styles/starwind.css
+++ b/src/styles/starwind.css
@@ -148,7 +148,7 @@
   --outline: #5279f2;
 
   /* sidebars variables */
-  --sidebar-background: #12141a;
+  --sidebar-background: #0b0c0f;
   --sidebar-foreground: #f5f7fb;
   --sidebar-primary: #5279f2;
   --sidebar-primary-foreground: #fff;
@@ -159,6 +159,32 @@
 }
 
 @layer components {
+  /*
+   * Tailwind Preflight is deliberately omitted because Starlight owns the
+   * document reset. Restore only the neutral element defaults Starwind's
+   * component classes expect so browser-native buttons and list markers do
+   * not leak into the component system.
+   */
+  :where(button[data-slot], button[data-sidebar]) {
+    appearance: none;
+    margin: 0;
+    border-width: 0;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+  }
+
+  :where(
+    [data-slot='sidebar-menu'],
+    [data-slot='sidebar-menu-sub'],
+    [data-slot='sidebar-menu-item'],
+    [data-slot='sidebar-menu-sub-item']
+  ) {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
   [data-slot] {
     border-color: var(--border);
   }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -83,8 +83,19 @@ html[data-theme='dark'] {
   --accent-on-solid: #0b0c0f;
   --status-warning: #ff776b;
   --sl-color-accent-low: var(--accent-soft);
+  --sl-color-accent: var(--cobalt);
   --sl-color-accent-high: var(--accent-strong);
+  --sl-color-white: var(--ink);
+  --sl-color-gray-1: #e7eaf0;
+  --sl-color-gray-2: #c7ccd5;
+  --sl-color-gray-3: var(--slate);
+  --sl-color-gray-4: #6f7682;
+  --sl-color-gray-5: var(--rule);
+  --sl-color-gray-6: var(--surface-subtle);
+  --sl-color-black: var(--white);
+  --sl-color-bg: var(--white);
   --sl-color-bg-nav: rgba(11, 12, 15, .96);
+  --sl-color-bg-sidebar: var(--white);
   color-scheme: dark;
 }
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -181,6 +181,8 @@ body {
 .site-name, .site-footer .footer-site-name, .provider-tabs a[aria-current='page'], .publication-sidebar a[aria-current='page'],
 .right-sidebar a[aria-current='true'] { font-weight: 600; }
 
+:where(button[data-slot], button[data-sidebar]) { font: inherit; }
+
 .mobile-site-menu nav a {
   font-family: var(--font-sans);
   font-size: 1rem;


### PR DESCRIPTION
## summary

- restore the neutral browser defaults Starwind expects without enabling Tailwind Preflight
- unify light and dark tokens, header controls, and sidebar surfaces
- remove sidebar list markers and connector rules while retaining indentation and active fills
- make Starwind the sole theme owner and keep Starlight synchronized through a compatibility provider
- add navigation regressions for control sizing, theme coherence, sidebar alignment, and marker removal

## verification

- `bun run verify`
- rendered browser review in light and dark themes
- ClientRouter theme transition review from Grok overview to configuration
