### PR TITLE
fix(ui): compact responsive publication controls

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { unified } from '@astrojs/markdown-remark';
 import { defineConfig } from 'astro/config';
 import { contentRedirects } from './src/content-manifest.mjs';
 import { site } from './src/site';
+import starlightDevSearch from './src/integrations/starlight-dev-search.mjs';
 import linkMetadata from './src/rehype/link-metadata.mjs';
 import publicationElements from './src/rehype/publication-elements.mjs';
 
@@ -55,6 +56,6 @@ export default defineConfig({
   ],
 
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [starlightDevSearch(), tailwindcss()],
   },
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ajv": "8.20.0"
   },
   "scripts": {
+    "predev": "node node_modules/astro/bin/astro.mjs build",
     "dev": "node node_modules/astro/bin/astro.mjs dev",
     "build": "node node_modules/astro/bin/astro.mjs build",
     "check": "node node_modules/astro/bin/astro.mjs check",
@@ -19,11 +20,12 @@
     "check:performance": "node scripts/check-performance.mjs",
     "test:site": "node scripts/check-typography.mjs && node scripts/test-site.mjs",
     "test:navigation": "node scripts/test-navigation.mjs",
+    "test:dev-search": "node scripts/test-dev-search.mjs",
     "test:a11y": "node scripts/test-a11y.mjs",
     "audit:performance": "node scripts/audit-performance.mjs",
     "preview": "node node_modules/astro/bin/astro.mjs preview",
     "sync:readme": "bun scripts/sync-readme.ts",
-    "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:navigation && bun run test:a11y"
+    "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:navigation && bun run test:dev-search && bun run test:a11y"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.4",

--- a/scripts/test-dev-search.mjs
+++ b/scripts/test-dev-search.mjs
@@ -1,0 +1,63 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from '@playwright/test';
+
+const localOrigin = 'http://127.0.0.1:4331';
+const isolatedOrigin = 'http://127.0.0.1:4177';
+const astro = path.join(process.cwd(), 'node_modules/astro/bin/astro.mjs');
+const build = spawnSync(process.execPath, [astro, 'build'], { stdio: 'inherit' });
+if (build.status !== 0) process.exit(build.status ?? 1);
+let origin = isolatedOrigin;
+let server;
+let serverExit;
+let browser;
+
+try {
+  try {
+    if ((await fetch(localOrigin)).ok) origin = localOrigin;
+  } catch {}
+
+  if (origin === isolatedOrigin) {
+    server = spawn(process.execPath, [astro, 'dev', '--host', '127.0.0.1', '--port', '4177'], { stdio: 'inherit' });
+    serverExit = once(server, 'exit');
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      try { if ((await fetch(origin)).ok) break; } catch {}
+      if (attempt === 39) throw new Error('astro development server did not become ready');
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 820, height: 856 } });
+  const errors = [];
+  page.on('console', (message) => { if (message.type() === 'error') errors.push(message.text()); });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  await page.goto(`${origin}/guides/codex/`, { waitUntil: 'networkidle' });
+  await page.locator('.header-search [data-open-modal]').click();
+  const search = page.locator('.header-search site-search dialog');
+  await search.waitFor({ state: 'visible' });
+  const input = search.locator('input[type="text"], input[type="search"]').first();
+  const inputSpacing = await input.evaluate((element) => {
+    const inputStyles = getComputedStyle(element);
+    const form = element.closest('form');
+    const iconStyles = getComputedStyle(form, '::before');
+    return Number.parseFloat(inputStyles.paddingInlineStart)
+      - Number.parseFloat(iconStyles.left)
+      - Number.parseFloat(iconStyles.width);
+  });
+  if (inputSpacing < 8) throw new Error('local search query text overlaps the search icon');
+  await input.fill('configuration');
+  const result = search.locator('.pagefind-ui__result').first();
+  await result.waitFor({ state: 'visible', timeout: 5000 });
+  if (!(await result.textContent())?.toLowerCase().includes('configuration')) throw new Error('local search did not return the expected guide result');
+  if (errors.length) throw new Error(`local search console errors: ${errors.join(' | ')}`);
+} finally {
+  await browser?.close();
+  if (server && server.exitCode === null && server.signalCode === null) server.kill('SIGTERM');
+  if (serverExit) await serverExit;
+}
+
+console.log('local development search loaded the Pagefind index and returned results');

--- a/scripts/test-navigation.mjs
+++ b/scripts/test-navigation.mjs
@@ -55,9 +55,30 @@ try {
       mobileTrigger: getComputedStyle(document.querySelector('.mobile-site-menu-trigger')).display,
       progress: getComputedStyle(document.querySelector('.reading-progress-rail')).display,
       dualBar: document.querySelectorAll('.mobile-toc, .guide-context-bar').length,
+      headerHeight: document.querySelector('.site-header').getBoundingClientRect().height,
+      tabsHeight: Math.max(...[...document.querySelectorAll('.provider-tabs a')].map((link) => link.getBoundingClientRect().height)),
+      searchHeight: document.querySelector('.header-search site-search > button').getBoundingClientRect().height,
+      headerControlHeights: [...document.querySelectorAll('.site-header-control')]
+        .map((control) => control.getBoundingClientRect())
+        .filter((bounds) => bounds.width > 0)
+        .map((bounds) => bounds.height),
+      pageActionHeights: [...document.querySelectorAll('.page-actions button')].map((control) => control.getBoundingClientRect().height),
+      headerGroupsOverlap: (() => {
+        const groups = [...document.querySelectorAll('.site-name, .provider-tabs, .header-actions')]
+          .map((element) => element.getBoundingClientRect());
+        return groups.some((first, index) => groups.slice(index + 1).some((second) =>
+          first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top
+        ));
+      })(),
     }));
     expect(layout.overflow === 0, `${viewport.width}px layout has horizontal overflow: ${layout.overflow}`);
     expect(layout.dualBar === 0, `${viewport.width}px layout renders the retired intermediate navigation bar`);
+    expect(layout.tabsHeight <= 32, `${viewport.width}px provider tabs exceed the compact 32px rhythm`);
+    expect(layout.searchHeight === 32, `${viewport.width}px search trigger does not use the compact 32px height`);
+    expect(layout.headerControlHeights.every((height) => height === 32), `${viewport.width}px header actions do not share the compact 32px height`);
+    expect(layout.pageActionHeights.every((height) => height === 32), `${viewport.width}px page actions do not share the compact 32px height`);
+    expect(!layout.headerGroupsOverlap, `${viewport.width}px header groups overlap`);
+    expect(Math.abs(layout.headerHeight - (viewport.width < 960 ? 92 : 64)) <= 1, `${viewport.width}px header height does not match its responsive row layout`);
     if (viewport.width < 768) {
       expect(layout.sidebar === 'none', 'mobile layout renders the desktop sidebar');
       expect(layout.mobileTrigger !== 'none', 'mobile layout hides the Sheet trigger');
@@ -174,7 +195,7 @@ try {
       leftAlignmentDelta: Math.abs(siteMark.left - railMark.left),
     };
   });
-  expect(chromeStyles.controls.every((control) => control.width === 36 && control.height === 36), 'header and sidebar controls do not share a 36px footprint');
+  expect(chromeStyles.controls.every((control) => control.width === 32 && control.height === 32), 'header and sidebar controls do not share a compact 32px footprint');
   expect(chromeStyles.controls.every((control) => control.borderStyle !== 'outset'), 'native browser borders leak into Starwind controls');
   expect(chromeStyles.listMarkers === 0, 'browser list markers leak into the guide sidebar');
   expect(chromeStyles.outlineRule === '0px', 'the retired heading connector rule remains visible');

--- a/scripts/test-navigation.mjs
+++ b/scripts/test-navigation.mjs
@@ -223,6 +223,25 @@ try {
   expect(await sidebar.getAttribute('data-state') === 'expanded', 'desktop sidebar is not expanded initially');
   await sidebarTrigger.click();
   expect(await sidebar.getAttribute('data-state') === 'collapsed', 'desktop sidebar did not collapse');
+  await page.waitForFunction(() => Math.abs(document.querySelector('.publication-sidebar')?.getBoundingClientRect().width - 56) < 1);
+  const collapsedAlignment = await page.evaluate(() => {
+    const visible = (selector) => [...document.querySelectorAll(selector)].find((element) => element.getClientRects().length > 0);
+    const rail = visible('.publication-sidebar').getBoundingClientRect();
+    const trigger = visible('[data-sw-sidebar-trigger]').getBoundingClientRect();
+    const chapterButtons = [...document.querySelectorAll('[data-sidebar="menu-button"]')]
+      .filter((element) => element.getClientRects().length > 0)
+      .map((element) => element.getBoundingClientRect());
+    const center = (bounds) => bounds.left + bounds.width / 2;
+    return {
+      triggerDelta: Math.abs(center(trigger) - center(rail)),
+      chapterDeltas: chapterButtons.map((button) => Math.abs(center(button) - center(rail))),
+      horizontalInset: (rail.width - trigger.width) / 2,
+      verticalInset: (visible('.handbook-rail-head').getBoundingClientRect().height - trigger.height) / 2,
+    };
+  });
+  expect(collapsedAlignment.triggerDelta < 1, 'collapsed sidebar trigger is not centered in the rail');
+  expect(collapsedAlignment.chapterDeltas.every((delta) => delta < 1), 'collapsed chapter buttons are not centered in the rail');
+  expect(Math.abs(collapsedAlignment.horizontalInset - collapsedAlignment.verticalInset) < 1, 'collapsed sidebar trigger does not have equal vertical and horizontal spacing');
   expect(await page.locator('[aria-label="codex handbook chapters"] .sidebar-page-outline').evaluate((outline) => getComputedStyle(outline).display) === 'none', 'heading outline remains visible in icon-collapse mode');
   expect(await page.locator('.right-sidebar-container').evaluate((rail) => rail.getBoundingClientRect().width) === 0, 'retired right sidebar retains width');
   await sidebarTrigger.click();

--- a/src/integrations/starlight-dev-search.mjs
+++ b/src/integrations/starlight-dev-search.mjs
@@ -1,0 +1,42 @@
+import { createReadStream, statSync } from 'node:fs';
+import path from 'node:path';
+
+const contentTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.wasm', 'application/wasm'],
+]);
+
+export default function starlightDevSearch() {
+  const pagefindDirectory = path.resolve('dist/pagefind');
+
+  return {
+    name: 'starlight-dev-search',
+    apply: 'serve',
+    enforce: 'pre',
+    transform(source, id) {
+      if (!id.includes('@astrojs/starlight/components/Search.astro')) return;
+      return source.replaceAll('import.meta.env.DEV', 'false');
+    },
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        const pathname = new URL(request.url ?? '/', 'http://localhost').pathname;
+        if (!pathname.startsWith('/pagefind/')) return next();
+
+        let filePath;
+        try {
+          const relativePath = decodeURIComponent(pathname.slice('/pagefind/'.length));
+          filePath = path.resolve(pagefindDirectory, relativePath);
+          if (!filePath.startsWith(`${pagefindDirectory}${path.sep}`) || !statSync(filePath).isFile()) return next();
+        } catch {
+          return next();
+        }
+
+        response.setHeader('Content-Type', contentTypes.get(path.extname(filePath)) ?? 'application/octet-stream');
+        response.setHeader('Cache-Control', 'no-store');
+        createReadStream(filePath).pipe(response);
+      });
+    },
+  };
+}

--- a/src/styles/guide-navigation.css
+++ b/src/styles/guide-navigation.css
@@ -135,7 +135,13 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 
 .publication-sidebar[data-state='collapsed'] .guide-rail-identity,
 .publication-sidebar[data-state='collapsed'] .sidebar-page-outline { display: none; }
-.publication-sidebar[data-state='collapsed'] .handbook-rail-head { justify-content: center; padding-inline: 0; }
+.publication-sidebar[data-state='collapsed'] .handbook-rail-head {
+  min-block-size: var(--rail-collapsed-width);
+  block-size: var(--rail-collapsed-width);
+  justify-content: center;
+  padding: .75rem;
+}
+.publication-sidebar[data-state='collapsed'] .publication-sidebar-content { padding-inline: .5rem; }
 .publication-sidebar[data-state='collapsed'] [data-sidebar='menu-button'] {
   inline-size: 2.5rem;
   min-block-size: 2.5rem;

--- a/src/styles/guide-navigation.css
+++ b/src/styles/guide-navigation.css
@@ -52,9 +52,9 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 }
 
 .publication-sidebar [data-sw-sidebar-trigger] {
-  inline-size: 2.25rem;
-  min-inline-size: 2.25rem;
-  block-size: 2.25rem;
+  inline-size: 2rem;
+  min-inline-size: 2rem;
+  block-size: 2rem;
   padding: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -164,6 +164,10 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 @media (min-width: 48rem) and (max-width: 71.99rem) {
   .main-frame { padding-inline-start: var(--left-rail-width) !important; }
   .main-pane .sl-container { max-width: 52rem; margin-inline: auto; }
+}
+
+@media (min-width: 48rem) and (max-width: 59.99rem) {
+  .handbook-rail-head { min-block-size: 3.25rem; }
 }
 
 @media (min-width: 80rem) {

--- a/src/styles/publication.css
+++ b/src/styles/publication.css
@@ -41,7 +41,11 @@ header.header { z-index: var(--z-navigation); height: var(--site-header-height);
 .page-title-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: start; gap: 1rem; }
 #_top { min-inline-size: 0; margin: 0; color: var(--ink); }
 .page-meta { display: flex; flex-wrap: wrap; gap: .5rem 1.5rem; margin: 1.125rem 0 0; }
-.page-actions { margin: .2rem 0 0; }
+.page-actions { margin: .15rem 0 0; }
+.page-actions :where(button, a) { min-block-size: 2rem; block-size: 2rem; }
+.page-actions .page-copy-button { padding-inline: .625rem; }
+.page-actions [aria-label='more page actions'] { inline-size: 2rem; min-inline-size: 2rem; padding: 0; }
+.page-actions :where(button, a) svg { inline-size: .9rem; block-size: .9rem; }
 .right-sidebar-container {
   flex: 0 0 var(--right-rail-width) !important;
   width: var(--right-rail-width) !important;
@@ -128,6 +132,6 @@ header.header { z-index: var(--z-navigation); height: var(--site-header-height);
 }
 
 @media (max-width: 39.99rem) {
-  .page-title-row { grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: .5rem; }
+  .page-title-row { grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: .375rem; }
   .page-actions { justify-self: end; margin-top: 0; }
 }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -12,9 +12,9 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .header-main { display: contents; }
 .site-name { grid-column: 1; grid-row: 1; display: inline-flex; align-items: center; gap: .7rem; width: max-content; text-decoration: none; }
 .site-name img { inline-size: 1.5rem; block-size: 1.5rem; flex: none; border-radius: var(--radius-ui); }
-.provider-tabs { grid-column: 2; grid-row: 1; min-inline-size: 0; padding: .3rem 0; display: flex; align-items: center; justify-content: center; gap: clamp(.45rem, 2vw, 1.35rem); overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: none; }
+.provider-tabs { grid-column: 2; grid-row: 1; min-inline-size: 0; padding: .25rem 0; display: flex; align-items: center; justify-content: center; gap: clamp(.35rem, 1.4vw, 1rem); overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: none; }
 .provider-tabs::-webkit-scrollbar { display: none; }
-.provider-tabs a { position: relative; isolation: isolate; min-height: 2.1rem; display: grid; place-items: center; padding: .35rem .72rem; border-radius: var(--radius-md); color: var(--slate); text-decoration: none; white-space: nowrap; }
+.provider-tabs a { position: relative; isolation: isolate; min-height: 2rem; display: grid; place-items: center; padding: .3rem .625rem; border-radius: var(--radius-md); color: var(--slate); text-decoration: none; white-space: nowrap; }
 .provider-tab-highlight { position: absolute; z-index: -1; inset: 0; border-radius: inherit; background: var(--cobalt); opacity: 0; }
 .provider-tab-label { position: relative; }
 .provider-tabs a:hover { background: var(--soft); color: var(--ink); }
@@ -34,11 +34,11 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .site-header-control [data-theme-icon-wrapper],
 .site-header-control [data-theme-icon] { inline-size: 1.125rem; block-size: 1.125rem; }
 .header-search site-search > button,
-.site-header-control { min-block-size: 2.25rem; border-radius: var(--radius-md); }
+.site-header-control { min-block-size: 2rem; border-radius: var(--radius-md); }
 .site-header-control {
-  inline-size: 2.25rem;
-  min-inline-size: 2.25rem;
-  block-size: 2.25rem;
+  inline-size: 2rem;
+  min-inline-size: 2rem;
+  block-size: 2rem;
   padding: 0;
   border: 1px solid transparent;
   background: transparent;
@@ -47,7 +47,7 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 }
 .site-header-control:hover { border-color: transparent; background: var(--soft); color: var(--ink); }
 .site-header-control:focus-visible { border-color: var(--cobalt); background: var(--soft); color: var(--ink); }
-.header-search site-search > button { min-inline-size: 7.75rem; block-size: 2.25rem; border: 1px solid var(--rule); background: color-mix(in srgb, var(--surface-subtle) 58%, transparent); color: var(--slate); }
+.header-search site-search > button { min-inline-size: 7rem; block-size: 2rem; padding-inline: .55rem; border: 1px solid var(--rule); background: color-mix(in srgb, var(--surface-subtle) 58%, transparent); color: var(--slate); }
 .header-search site-search > button:hover,
 .header-search site-search > button:focus-visible { border-color: color-mix(in srgb, var(--cobalt) 58%, var(--rule)); background: var(--soft); color: var(--ink); }
 .header-search site-search > button kbd {
@@ -140,26 +140,52 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
   :root { --sl-content-pad-x: 1.5rem; }
 }
 
+@media (min-width: 60rem) and (max-width: 71.99rem) {
+  .site-header { grid-template-columns: minmax(9.5rem, 1fr) auto minmax(10.5rem, 1fr); }
+  .provider-tabs { gap: .2rem; }
+  .provider-tabs a { padding-inline: .5rem; }
+  .header-actions { gap: .25rem; }
+  .header-search site-search > button { min-inline-size: 6.5rem; }
+  .header-search site-search > button kbd { display: none; }
+}
+
+@media (min-width: 48rem) and (max-width: 59.99rem) {
+  :root { --site-header-height: 5.75rem; --sl-mobile-toc-height: 0rem; }
+  .site-header { grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: 3.25rem 2.5rem; }
+  .site-name { grid-column: 1; grid-row: 1; }
+  .header-actions { grid-column: 2; grid-row: 1; gap: .25rem; }
+  .provider-tabs { grid-column: 1 / -1; grid-row: 2; gap: .2rem; padding: .125rem 0 .375rem; }
+  .provider-tabs a { min-height: 1.875rem; padding: .25rem .6rem; }
+  .header-search site-search > button {
+    inline-size: 2rem;
+    min-inline-size: 2rem;
+    padding: 0;
+    justify-content: center;
+  }
+  .header-search site-search > button span,
+  .header-search site-search > button kbd { display: none; }
+}
+
 @media (max-width: 47.99rem) {
-  :root { --site-header-height: 6.65rem; --sl-mobile-toc-height: 0rem; }
-  .site-header { padding-inline: 0; grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: 3.9rem 2.75rem; }
+  :root { --site-header-height: 5.75rem; --sl-mobile-toc-height: 0rem; }
+  .site-header { padding-inline: 0; grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: 3.25rem 2.5rem; }
   .site-name { grid-column: 1; grid-row: 1; margin-inline-start: var(--site-gutter); }
   .header-actions {
     grid-column: 2;
     grid-row: 1;
     gap: .125rem;
     margin-inline-end: var(--site-gutter);
-    padding: .1875rem;
+    padding: .125rem;
     border: 1px solid var(--rule);
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--surface-subtle) 58%, transparent);
   }
   .header-search site-search > button,
   .site-header-control {
-    inline-size: 2.25rem;
-    min-inline-size: 2.25rem;
-    block-size: 2.25rem;
-    min-block-size: 2.25rem;
+    inline-size: 2rem;
+    min-inline-size: 2rem;
+    block-size: 2rem;
+    min-block-size: 2rem;
     padding: 0;
     border: 0;
     border-radius: var(--radius-sm);
@@ -172,9 +198,9 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
   .site-header-control:focus-visible { border-color: transparent; background: var(--soft); }
   .header-search site-search > button span,
   .header-search site-search > button kbd { display: none; }
-  .header-actions > .github-link { display: none; }
-  .provider-tabs { grid-column: 1 / -1; grid-row: 2; justify-content: center; gap: .25rem; padding-inline: var(--site-gutter); }
-  .provider-tabs a { min-height: 2rem; padding-inline: .55rem; }
+  .header-actions .github-link { display: none; }
+  .provider-tabs { grid-column: 1 / -1; grid-row: 2; justify-content: center; gap: .125rem; padding: .125rem var(--site-gutter) .375rem; }
+  .provider-tabs a { min-height: 1.875rem; padding: .25rem .5rem; }
   .sidebar-pane { display: none !important; }
   .right-sidebar-container { display: block !important; flex: 0 0 0 !important; width: 0 !important; }
   .right-sidebar { width: 0 !important; border-inline-start: 0 !important; }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -74,7 +74,14 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
   --pagefind-ui-border-radius: var(--radius-md);
   --pagefind-ui-font: 'Instrument Sans', system-ui, sans-serif;
 }
-.header-search #starlight__search .pagefind-ui__search-input { min-block-size: 3.15rem; border-radius: var(--radius-md); background: var(--surface-subtle); color: var(--ink); }
+.header-search #starlight__search .pagefind-ui__search-input {
+  min-block-size: 3.15rem;
+  padding-inline-start: 3rem !important;
+  padding-inline-end: 3.75rem !important;
+  border-radius: var(--radius-md);
+  background: var(--surface-subtle);
+  color: var(--ink);
+}
 .header-search #starlight__search .pagefind-ui__search-input:focus { border-color: var(--cobalt); box-shadow: 0 0 0 3px var(--accent-soft); }
 .header-search #starlight__search .pagefind-ui__result { padding-block: 1rem; border-top-color: var(--rule); }
 .header-search #starlight__search .pagefind-ui__result-link { color: var(--ink); text-decoration: none; }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -242,7 +242,7 @@ body {
 
 .page-actions :where(button, a) {
   font-family: var(--font-sans);
-  font-size: .82rem;
+  font-size: .75rem;
   font-weight: 400;
   line-height: 1rem;
 }


### PR DESCRIPTION
## Summary

- compact the publication header, provider tabs, search trigger, and page actions across desktop, tablet, and mobile
- center the collapsed guide rail controls with equal square spacing
- make Starlight Pagefind search functional in Astro development while retaining the production search implementation
- add responsive geometry and local development search regression coverage

## Scope

This changes publication UI, development search integration, and tests only. Public prose, Markdown ownership, routes, and production search behavior remain unchanged.

## Verification

- `bun run verify`
- 15 canonical routes across 8 accessibility and reflow viewport modes
- local development Pagefind query and result navigation
- collapsed rail trigger and chapter centerline measurements
