### PR TITLE
feat(site): add bounded WebMCP handbook tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@types/mdast": "4.0.4",
         "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
+        "github-slugger": "2.0.0",
         "jsonc-parser": "3.3.1",
         "lighthouse": "13.4.1",
         "mdast-util-to-string": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "check:performance": "node scripts/check-performance.mjs",
     "test:site": "node scripts/check-typography.mjs && node scripts/test-site.mjs",
     "test:navigation": "node scripts/test-navigation.mjs",
+    "test:agent": "node scripts/test-agent-surface.mjs",
     "test:dev-search": "node scripts/test-dev-search.mjs",
     "test:a11y": "node scripts/test-a11y.mjs",
     "audit:performance": "node scripts/audit-performance.mjs",
     "preview": "node node_modules/astro/bin/astro.mjs preview",
     "sync:readme": "bun scripts/sync-readme.ts",
-    "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:navigation && bun run test:dev-search && bun run test:a11y"
+    "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:agent && bun run test:navigation && bun run test:dev-search && bun run test:a11y"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.4",
@@ -51,6 +52,7 @@
     "@types/mdast": "4.0.4",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
+    "github-slugger": "2.0.0",
     "jsonc-parser": "3.3.1",
     "lighthouse": "13.4.1",
     "mdast-util-to-string": "4.0.0",

--- a/scripts/check-performance.mjs
+++ b/scripts/check-performance.mjs
@@ -19,6 +19,7 @@ const maxGuideCssGzipBytes = 32 * 1024;
 const maxGuideJavaScriptGzipBytes = 72 * 1024;
 const maxFontBytes = 80 * 1024;
 const maxFontFiles = 4;
+const maxAgentIndexGzipBytes = 32 * 1024;
 const canonicalRoutes = new Set(canonicalContentFiles().map(({ route }) => route));
 const providerRoutes = ['/guides/codex/', '/guides/claude-code/', '/guides/grok/'];
 const providerRouteSet = new Set(providerRoutes);
@@ -135,6 +136,8 @@ for (const tag of tagsByRoute.get('/handbook/history/') ?? []) {
 }
 
 const distRoot = path.join(root, 'dist');
+const agentIndexGzipBytes = gzipSync(await readFile(path.join(distRoot, 'agent-index.json'))).length;
+if (agentIndexGzipBytes > maxAgentIndexGzipBytes) failures.push(`${agentIndexGzipBytes} compressed agent index bytes exceeds 32 KiB`);
 const assetRoot = path.join(distRoot, '_astro');
 const guideStylesheets = new Set();
 const guideScripts = new Set();
@@ -144,6 +147,7 @@ for (const { route } of canonicalContentFiles().filter(({ route }) => route.star
   const htmlGzipBytes = gzipSync(html).length;
   if (htmlGzipBytes > maxGuideHtmlGzipBytes) failures.push(`${route}: ${htmlGzipBytes} compressed HTML bytes exceeds 24 KiB`);
   const source = html.toString();
+  if (new RegExp(`origin${'-'}trial|navigator\\.modelContext`).test(source)) failures.push(`${route}: unsupported WebMCP compatibility code is present`);
   if (source.includes('--surface-canvas:') || source.includes('--rail-expanded-width:')) failures.push(`${route}: shared site CSS is inlined into generated HTML`);
   for (const [tag] of source.matchAll(/<link\b[^>]*\brel="stylesheet"[^>]*>/g)) {
     if (tag.includes('media="print"')) continue;
@@ -188,4 +192,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`validated media, guide HTML, ${guideStylesheets.size} shared stylesheets, ${reachableScripts.size} reachable scripts, and ${fontFiles.length} font files against performance budgets`);
+console.log(`validated media, guide HTML, ${agentIndexGzipBytes} compressed agent-index bytes, ${guideStylesheets.size} shared stylesheets, ${reachableScripts.size} reachable scripts, and ${fontFiles.length} font files against performance budgets`);

--- a/scripts/check-ui-ownership.mjs
+++ b/scripts/check-ui-ownership.mjs
@@ -52,6 +52,8 @@ const prohibited = [
   ['native dialog state machine', /\.showModal\s*\(/],
   ['custom page-action disclosure', /<details[^>]+page-action/],
   ['custom mobile navigation disclosure', /<details[^>]+mobile-site-menu/],
+  ['deprecated navigator WebMCP alias', /navigator\.modelContext/],
+  ['WebMCP origin trial', new RegExp(`origin${'-'}trial`, 'i')],
 ];
 
 for (const [file, source] of repositoryText) {
@@ -66,6 +68,7 @@ const allowedControllers = new Set([
   'src/components/StarlightPageTitle.astro',
   'src/components/StarlightThemeProvider.astro',
   'src/components/ThemeBridge.astro',
+  'src/components/WebMcpSurface.astro',
 ]);
 for (const [file, source] of repositoryText) {
   if (file.startsWith('src/components/starwind/') || !file.startsWith('src/components/')) continue;

--- a/scripts/test-agent-surface.mjs
+++ b/scripts/test-agent-surface.mjs
@@ -6,12 +6,15 @@ import path from 'node:path';
 import process from 'node:process';
 import { chromium } from '@playwright/test';
 import { AGENT_TOOL_NAMES, AGENT_TOOL_SCHEMAS, createHandbookTools } from '../src/agent-contract.mjs';
-import { buildAgentIndex, splitCanonicalMarkdown } from '../src/agent-index.mjs';
+import { buildAgentIndex, normalizePublicText, splitCanonicalMarkdown } from '../src/agent-index.mjs';
 import { canonicalContentFiles } from '../src/content-manifest.mjs';
 
 const root = process.cwd();
 const dist = path.join(root, 'dist');
 const index = JSON.parse(await readFile(path.join(dist, 'agent-index.json'), 'utf8'));
+assert.equal(normalizePublicText('&amp;lt;script&amp;gt;'), '&lt;script&gt;', 'entity decoding must remain single pass');
+assert.equal(normalizePublicText('&amp;amp;lt;'), '&amp;lt;', 'nested ampersand entities must decode by exactly one level');
+assert.notEqual(normalizePublicText('&amp;amp;lt;'), '&lt;', 'nested ampersand entities must never decode twice');
 assert.deepEqual(index, await buildAgentIndex(root), 'built agent index must exactly match canonical content');
 process.chdir(path.dirname(root));
 assert.deepEqual(index, await buildAgentIndex(root), 'explicit-root generation must be independent of caller cwd');

--- a/scripts/test-agent-surface.mjs
+++ b/scripts/test-agent-surface.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from '@playwright/test';
+import { AGENT_TOOL_NAMES, AGENT_TOOL_SCHEMAS, createHandbookTools } from '../src/agent-contract.mjs';
+import { buildAgentIndex, splitCanonicalMarkdown } from '../src/agent-index.mjs';
+import { canonicalContentFiles } from '../src/content-manifest.mjs';
+
+const root = process.cwd();
+const dist = path.join(root, 'dist');
+const index = JSON.parse(await readFile(path.join(dist, 'agent-index.json'), 'utf8'));
+assert.deepEqual(index, await buildAgentIndex(root), 'built agent index must exactly match canonical content');
+process.chdir(path.dirname(root));
+assert.deepEqual(index, await buildAgentIndex(root), 'explicit-root generation must be independent of caller cwd');
+process.chdir(root);
+assert.deepEqual(index.pages.map(({ route }) => route), canonicalContentFiles().map(({ route }) => route).sort((a, b) => a === '/' ? -1 : b === '/' ? 1 : a.localeCompare(b)));
+assert.equal(index.discovery.llms, '/llms.txt');
+assert.equal(index.discovery.index, '/agent-index.json');
+assert.ok(index.pages.every((page) => page.text && page.sections.every((section) => section.anchor && section.title)));
+assert.ok(index.sources.every((source) => Object.keys(source).sort().join(',') === 'evidence,id,publisher,title,url'));
+assert.ok(index.sources.every((source) => Object.keys(source.publisher ?? {}).sort().join(',') === 'domain,id,label'));
+assert.ok(index.pages.flatMap((page) => page.sourceIds).every((id) => index.sources.some((source) => source.id === id)));
+const homeSource = await readFile(path.join(root, 'content/home.md'), 'utf8');
+assert.equal(await readFile(path.join(dist, 'index.md'), 'utf8'), `${splitCanonicalMarkdown(homeSource).body.trim()}\n`, 'homepage Markdown endpoint must preserve canonical text');
+
+const navigated = [];
+const tools = createHandbookTools({ loadIndex: async () => index, navigate: async (target) => navigated.push(target) });
+assert.deepEqual(tools.map(({ name }) => name), AGENT_TOOL_NAMES);
+for (const name of AGENT_TOOL_NAMES) assert.equal(AGENT_TOOL_SCHEMAS[name].additionalProperties, false, `${name} schema must reject extra properties`);
+assert.equal((await tools[0].execute({ scope: 'codex', limit: 2 })).data.pages.length, 2);
+assert.equal((await tools[0].execute({ unexpected: true })).error.code, 'invalid_input');
+const search = await tools[1].execute({ query: 'codex', limit: 3 });
+assert.equal(search.ok, true);
+assert.deepEqual(search, await tools[1].execute({ query: 'codex', limit: 3 }), 'search ordering must be deterministic');
+assert.equal((await tools[1].execute({ query: '', limit: 3 })).error.code, 'invalid_input');
+assert.equal((await tools[2].execute({ route: '/guides/codex/', anchor: 'one-engineering-loop-several-control-rooms', maxCharacters: 250 })).data.section.text.length <= 250, true);
+assert.equal((await tools[2].execute({ route: '/guides/codex/', anchor: 'missing' })).error.code, 'not_found');
+const source = await tools[3].execute({ sourceId: 'openai-codex-manual' });
+assert.equal(source.ok, true);
+assert.deepEqual(Object.keys(source.data.source).sort(), ['evidence', 'id', 'publisher', 'title', 'url']);
+assert.equal((await tools[3].execute({ sourceId: 'private-or-unknown' })).error.code, 'not_found');
+assert.equal((await tools[4].execute({ route: 'https://example.com/' })).error.code, 'navigation_rejected');
+assert.equal((await tools[4].execute({ route: '//example.com/' })).error.code, 'navigation_rejected');
+assert.equal((await tools[4].execute({ route: '/guides/codex/', anchor: 'missing' })).error.code, 'navigation_rejected');
+assert.equal((await tools[4].execute({ route: '/guides/codex/', anchor: 'this-is-codex' })).ok, true);
+assert.deepEqual(navigated, ['/guides/codex/#this-is-codex']);
+
+const port = 4178;
+const origin = `http://127.0.0.1:${port}`;
+const vite = path.join(root, 'node_modules/vite/bin/vite.js');
+const server = spawn(process.execPath, [vite, 'preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'], { stdio: 'inherit' });
+const serverExit = once(server, 'exit');
+let browser;
+
+try {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try { if ((await fetch(origin)).ok) break; } catch {}
+    if (attempt === 39) throw new Error('preview did not become ready');
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  browser = await chromium.launch({ headless: true });
+  const supported = await browser.newContext();
+  await supported.addInitScript(() => {
+    const active = new Map();
+    const calls = [];
+    let maximumActive = 0;
+    const context = {
+      async registerTool(tool, options = {}) {
+        if (active.has(tool.name)) throw new Error(`duplicate tool: ${tool.name}`);
+        active.set(tool.name, tool);
+        calls.push(tool.name);
+        maximumActive = Math.max(maximumActive, active.size);
+        options.signal?.addEventListener('abort', () => active.delete(tool.name), { once: true });
+      },
+    };
+    Object.defineProperty(Document.prototype, 'modelContext', { configurable: true, get: () => context });
+    window.__webmcpTest = {
+      activeNames: () => [...active.keys()],
+      callCount: () => calls.length,
+      maximumActive: () => maximumActive,
+      execute: (name, input) => active.get(name).execute(input),
+    };
+    window.__agentDocumentToken = crypto.randomUUID();
+  });
+  const page = await supported.newPage();
+  const errors = [];
+  page.on('console', (message) => { if (message.type() === 'error') errors.push(message.text()); });
+  page.on('pageerror', (error) => errors.push(error.message));
+  await page.goto(`${origin}/guides/codex/`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => window.__webmcpTest?.activeNames().length === 5);
+  assert.deepEqual(await page.evaluate(() => window.__webmcpTest.activeNames()), AGENT_TOOL_NAMES);
+  const token = await page.evaluate(() => window.__agentDocumentToken);
+  await page.evaluate(() => window.__webmcpTest.execute('open_handbook_page', { route: '/guides/codex/configuration/' }));
+  await page.waitForURL('**/guides/codex/configuration/');
+  await page.waitForFunction(() => window.__webmcpTest?.callCount() === 10 && window.__webmcpTest.activeNames().length === 5);
+  assert.equal(await page.evaluate(() => window.__agentDocumentToken), token, 'WebMCP navigation must preserve ClientRouter document continuity');
+  assert.equal(await page.evaluate(() => window.__webmcpTest.maximumActive()), 5, 'registrations must abort before replacement');
+  assert.deepEqual(await page.evaluate(() => window.__webmcpTest.activeNames()), AGENT_TOOL_NAMES);
+  assert.deepEqual(errors, []);
+  const supportedText = (await page.locator('body').innerText()).replace(/\s+/g, ' ').trim();
+  await supported.close();
+
+  const unsupported = await browser.newContext();
+  const fallbackPage = await unsupported.newPage();
+  const fallbackErrors = [];
+  fallbackPage.on('console', (message) => { if (message.type() === 'error') fallbackErrors.push(message.text()); });
+  fallbackPage.on('pageerror', (error) => fallbackErrors.push(error.message));
+  await fallbackPage.goto(`${origin}/guides/codex/configuration/`, { waitUntil: 'networkidle' });
+  assert.equal(await fallbackPage.evaluate(() => document.modelContext), undefined);
+  assert.equal(await fallbackPage.locator('[data-webmcp], webmcp').count(), 0, 'agent surface must render no visible UI');
+  assert.equal((await fallbackPage.locator('body').innerText()).replace(/\s+/g, ' ').trim(), supportedText, 'WebMCP support must not alter public text');
+  assert.deepEqual(fallbackErrors, []);
+  await unsupported.close();
+
+  const noJavaScript = await browser.newContext({ javaScriptEnabled: false });
+  const staticPage = await noJavaScript.newPage();
+  await staticPage.goto(`${origin}/`, { waitUntil: 'load' });
+  const href = await staticPage.locator('a[href="/guides/codex/"]').first().getAttribute('href');
+  assert.equal(href, '/guides/codex/');
+  await staticPage.goto(`${origin}${href}`, { waitUntil: 'load' });
+  assert.equal(new URL(staticPage.url()).pathname, '/guides/codex/');
+  assert.equal((await staticPage.request.get(`${origin}/agent-index.json`)).status(), 200);
+  await noJavaScript.close();
+} finally {
+  await browser?.close();
+  server.kill('SIGTERM');
+  await Promise.race([serverExit, new Promise((resolve) => setTimeout(resolve, 2000))]);
+}
+
+console.log(`validated ${index.pages.length} indexed pages, ${index.sources.length} public sources, five bounded tools, and progressive WebMCP lifecycle behavior`);

--- a/scripts/test-site.mjs
+++ b/scripts/test-site.mjs
@@ -92,6 +92,7 @@ for (const [route, source] of contentFiles) {
 
 try {
   const llms = await readFile(path.join(dist, 'llms.txt'), 'utf8');
+  if (!llms.includes(`${origin}/agent-index.json`)) failures.push('/llms.txt: structured agent index discovery link is missing');
   for (const { route, file, kind } of canonicalContentFiles().filter((entry) => entry.kind === 'home' || entry.kind === 'guide')) {
     const markdown = await readFile(file, 'utf8');
     const title = scalar(markdown, 'title');
@@ -101,6 +102,18 @@ try {
   }
   if (llms.includes('/changes/') || llms.includes('/field-lab/')) failures.push('/llms.txt: redirected route is present');
 } catch { failures.push('/llms.txt: generated index is missing'); }
+
+try {
+  const agentIndex = JSON.parse(await readFile(path.join(dist, 'agent-index.json'), 'utf8'));
+  if (agentIndex.discovery?.llms !== '/llms.txt' || agentIndex.discovery?.index !== '/agent-index.json') failures.push('/agent-index.json: discovery metadata is incorrect');
+  if (agentIndex.pages?.length !== contentFiles.length) failures.push('/agent-index.json: canonical route parity is incorrect');
+} catch { failures.push('/agent-index.json: generated structured index is missing or invalid'); }
+
+try {
+  const homepageMarkdown = await readFile(path.join(dist, 'index.md'), 'utf8');
+  const canonicalBody = homeSource.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '').trim();
+  if (homepageMarkdown !== `${canonicalBody}\n`) failures.push('/index.md: generated homepage Markdown differs from canonical content');
+} catch { failures.push('/index.md: generated homepage Markdown is missing'); }
 
 const activeGuideText = (await Promise.all(contentFiles.map(([, source]) => readFile(source, 'utf8')))).join('\n');
 for (const version of Object.values(registry.product_versions)) {

--- a/src/agent-contract.mjs
+++ b/src/agent-contract.mjs
@@ -1,0 +1,196 @@
+import { AGENT_INDEX_VERSION } from './agent-index-version.mjs';
+
+export const AGENT_TOOL_NAMES = [
+  'list_handbook_pages',
+  'search_handbook',
+  'read_handbook_section',
+  'inspect_source',
+  'open_handbook_page',
+];
+
+const scopes = ['handbook', 'codex', 'claude-code', 'grok'];
+const noExtraProperties = { additionalProperties: false };
+const schema = (properties, required = []) => ({ type: 'object', properties, required, ...noExtraProperties });
+const string = (description, maxLength, extra = {}) => ({ type: 'string', description, maxLength, ...extra });
+const integer = (description, maximum, defaultValue) => ({ type: 'integer', description, minimum: 1, maximum, default: defaultValue });
+
+export const AGENT_TOOL_SCHEMAS = {
+  list_handbook_pages: schema({
+    scope: { type: 'string', description: 'Optional handbook or provider scope.', enum: scopes },
+    limit: integer('Maximum pages to return.', 30, 20),
+  }),
+  search_handbook: schema({
+    query: string('Words to find in public handbook text.', 120, { minLength: 1 }),
+    scope: { type: 'string', description: 'Optional handbook or provider scope.', enum: scopes },
+    limit: integer('Maximum matches to return.', 8, 5),
+  }, ['query']),
+  read_handbook_section: schema({
+    route: string('Canonical same-origin handbook route.', 200, { pattern: '^/' }),
+    anchor: string('Heading anchor or exact heading text.', 160, { minLength: 1 }),
+    maxCharacters: { type: 'integer', description: 'Maximum section characters.', minimum: 200, maximum: 1500, default: 1200 },
+  }, ['route', 'anchor']),
+  inspect_source: schema({
+    sourceId: string('Registered public source identifier.', 128, { minLength: 1 }),
+  }, ['sourceId']),
+  open_handbook_page: schema({
+    route: string('Canonical same-origin handbook route.', 200, { pattern: '^/' }),
+    anchor: string('Optional heading anchor on that page.', 160, { minLength: 1 }),
+  }, ['route']),
+};
+
+const ok = (data) => ({ schemaVersion: AGENT_INDEX_VERSION, ok: true, data });
+const fail = (code, message) => ({ schemaVersion: AGENT_INDEX_VERSION, ok: false, error: { code, message } });
+const plainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const exactKeys = (input, allowed) => Object.keys(input).every((key) => allowed.includes(key));
+const boundedInteger = (value, fallback, maximum, minimum = 1) => value === undefined ? fallback : Number.isInteger(value) && value >= minimum && value <= maximum ? value : null;
+const cleanString = (value, maximum, required = false) => {
+  if (value === undefined && !required) return undefined;
+  if (typeof value !== 'string') return null;
+  const clean = value.trim();
+  return clean.length >= (required ? 1 : 0) && clean.length <= maximum ? clean : null;
+};
+const pageSummary = (page) => ({
+  route: page.route,
+  markdownUrl: page.markdownUrl,
+  kind: page.kind,
+  title: page.title,
+  description: page.description,
+  updatedAt: page.updatedAt,
+  status: page.status,
+  evidence: page.evidence,
+  sourceIds: page.sourceIds,
+  scope: page.scope,
+});
+const normalizeRoute = (value) => value === '/' ? '/' : value.endsWith('/') ? value : `${value}/`;
+const findPage = (index, route) => index.pages.find((page) => page.route === normalizeRoute(route));
+const countMatches = (text, query) => text.toLocaleLowerCase().split(query).length - 1;
+const snippet = (text, query, maximum = 180) => {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  const match = normalized.toLocaleLowerCase().indexOf(query);
+  if (match < 0) return normalized.slice(0, maximum);
+  const start = Math.max(0, match - Math.floor(maximum / 3));
+  const end = Math.min(normalized.length, start + maximum);
+  return `${start > 0 ? '…' : ''}${normalized.slice(start, end).trim()}${end < normalized.length ? '…' : ''}`;
+};
+
+export function createHandbookTools({ loadIndex, navigate }) {
+  const withIndex = (execute) => async (input, options = {}) => {
+    if (options.signal?.aborted) return fail('aborted', 'The tool call was cancelled.');
+    try {
+      const index = await loadIndex(options.signal);
+      if (index?.schemaVersion !== AGENT_INDEX_VERSION) return fail('unavailable', 'The handbook index version is unavailable.');
+      return await execute(input, index, options);
+    } catch (error) {
+      if (options.signal?.aborted || error?.name === 'AbortError') return fail('aborted', 'The tool call was cancelled.');
+      return fail('unavailable', 'The handbook index could not be loaded.');
+    }
+  };
+
+  return [
+    {
+      name: 'list_handbook_pages',
+      title: 'List handbook pages',
+      description: 'Lists canonical public coding agent tips pages with route, update, evidence, and source provenance.',
+      inputSchema: AGENT_TOOL_SCHEMAS.list_handbook_pages,
+      annotations: { readOnlyHint: true, untrustedContentHint: false },
+      execute: withIndex((input, index) => {
+        if (!plainObject(input) || !exactKeys(input, ['scope', 'limit'])) return fail('invalid_input', 'Use only scope and limit.');
+        const scope = cleanString(input.scope, 32);
+        const limit = boundedInteger(input.limit, 20, 30);
+        if (scope === null || (scope !== undefined && !scopes.includes(scope)) || limit === null) return fail('invalid_input', 'Scope or limit is invalid.');
+        const pages = index.pages.filter((page) => !scope || page.scope === scope).slice(0, limit).map(pageSummary);
+        return ok({ pages, total: pages.length });
+      }),
+    },
+    {
+      name: 'search_handbook',
+      title: 'Search handbook',
+      description: 'Searches canonical public handbook text locally and returns bounded matches with provenance and normal URLs.',
+      inputSchema: AGENT_TOOL_SCHEMAS.search_handbook,
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: withIndex((input, index) => {
+        if (!plainObject(input) || !exactKeys(input, ['query', 'scope', 'limit'])) return fail('invalid_input', 'Use only query, scope, and limit.');
+        const query = cleanString(input.query, 120, true);
+        const scope = cleanString(input.scope, 32);
+        const limit = boundedInteger(input.limit, 5, 8);
+        if (query === null || scope === null || (scope !== undefined && !scopes.includes(scope)) || limit === null) return fail('invalid_input', 'Query, scope, or limit is invalid.');
+        const needle = query.toLocaleLowerCase();
+        const results = index.pages
+          .filter((page) => !scope || page.scope === scope)
+          .map((page) => {
+            const title = page.title.toLocaleLowerCase();
+            const description = page.description.toLocaleLowerCase();
+            const headings = page.sections.map((section) => section.title).join(' ').toLocaleLowerCase();
+            const body = page.text.toLocaleLowerCase();
+            const score = (title.includes(needle) ? 100 : 0) + (description.includes(needle) ? 40 : 0) + (headings.includes(needle) ? 25 : 0) + Math.min(20, countMatches(body, needle));
+            return { page, score };
+          })
+          .filter(({ score }) => score > 0)
+          .sort((left, right) => right.score - left.score || left.page.route.localeCompare(right.page.route))
+          .slice(0, limit)
+          .map(({ page, score }) => ({ ...pageSummary(page), score, snippet: snippet(page.text, needle) }));
+        return ok({ query, results, total: results.length });
+      }),
+    },
+    {
+      name: 'read_handbook_section',
+      title: 'Read handbook section',
+      description: 'Reads one public section by canonical route and heading anchor, returning bounded text and source provenance.',
+      inputSchema: AGENT_TOOL_SCHEMAS.read_handbook_section,
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: withIndex((input, index) => {
+        if (!plainObject(input) || !exactKeys(input, ['route', 'anchor', 'maxCharacters'])) return fail('invalid_input', 'Use only route, anchor, and maxCharacters.');
+        const route = cleanString(input.route, 200, true);
+        const anchor = cleanString(input.anchor, 160, true);
+        const maxCharacters = boundedInteger(input.maxCharacters, 1200, 1500, 200);
+        if (route === null || anchor === null || maxCharacters === null || !route.startsWith('/')) return fail('invalid_input', 'Route, anchor, or maxCharacters is invalid.');
+        const page = findPage(index, route);
+        if (!page) return fail('not_found', 'The canonical handbook route was not found.');
+        const normalizedAnchor = anchor.replace(/^#/, '').toLocaleLowerCase();
+        const section = page.sections.find((candidate) => candidate.anchor.toLocaleLowerCase() === normalizedAnchor || candidate.title.toLocaleLowerCase() === normalizedAnchor);
+        if (!section) return fail('not_found', 'The heading was not found on that page.');
+        const text = section.text.slice(0, maxCharacters);
+        return ok({ ...pageSummary(page), section: { anchor: section.anchor, title: section.title, depth: section.depth, text, truncated: text.length < section.text.length } });
+      }),
+    },
+    {
+      name: 'inspect_source',
+      title: 'Inspect source',
+      description: 'Returns the public title, publisher, URL, and evidence type for one source referenced by the handbook.',
+      inputSchema: AGENT_TOOL_SCHEMAS.inspect_source,
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      execute: withIndex((input, index) => {
+        if (!plainObject(input) || !exactKeys(input, ['sourceId'])) return fail('invalid_input', 'Use only sourceId.');
+        const sourceId = cleanString(input.sourceId, 128, true);
+        if (sourceId === null) return fail('invalid_input', 'SourceId is invalid.');
+        const source = index.sources.find((candidate) => candidate.id === sourceId);
+        return source ? ok({ source }) : fail('not_found', 'The public source was not found.');
+      }),
+    },
+    {
+      name: 'open_handbook_page',
+      title: 'Open handbook page',
+      description: 'Navigates to a validated canonical handbook route and optional heading on the current site.',
+      inputSchema: AGENT_TOOL_SCHEMAS.open_handbook_page,
+      annotations: { readOnlyHint: true, untrustedContentHint: false },
+      execute: withIndex(async (input, index) => {
+        if (!plainObject(input) || !exactKeys(input, ['route', 'anchor'])) return fail('invalid_input', 'Use only route and anchor.');
+        const route = cleanString(input.route, 200, true);
+        const anchor = cleanString(input.anchor, 160);
+        if (route === null || anchor === null || !route.startsWith('/') || route.startsWith('//')) return fail('navigation_rejected', 'Only canonical same-origin handbook routes are allowed.');
+        const page = findPage(index, route);
+        if (!page) return fail('navigation_rejected', 'The route is outside the canonical handbook.');
+        let resolvedAnchor;
+        if (anchor !== undefined) {
+          const normalizedAnchor = anchor.replace(/^#/, '').toLocaleLowerCase();
+          const section = page.sections.find((candidate) => candidate.anchor.toLocaleLowerCase() === normalizedAnchor || candidate.title.toLocaleLowerCase() === normalizedAnchor);
+          if (!section) return fail('navigation_rejected', 'The heading is outside the canonical page.');
+          resolvedAnchor = section.anchor;
+        }
+        const target = `${page.route}${resolvedAnchor ? `#${encodeURIComponent(resolvedAnchor)}` : ''}`;
+        await navigate(target);
+        return ok({ route: page.route, anchor: resolvedAnchor ?? null, target });
+      }),
+    },
+  ];
+}

--- a/src/agent-index-version.mjs
+++ b/src/agent-index-version.mjs
@@ -1,0 +1,1 @@
+export const AGENT_INDEX_VERSION = '1.0.0';

--- a/src/agent-index.mjs
+++ b/src/agent-index.mjs
@@ -1,0 +1,115 @@
+import { readFile } from 'node:fs/promises';
+import GithubSlugger from 'github-slugger';
+import { toString } from 'mdast-util-to-string';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import YAML from 'yaml';
+import sourceRegistry from '../editorial/sources.json' with { type: 'json' };
+import { canonicalContentFiles } from './content-manifest.mjs';
+import { AGENT_INDEX_VERSION } from './agent-index-version.mjs';
+
+export { AGENT_INDEX_VERSION } from './agent-index-version.mjs';
+
+const decodeEntities = (value) => value
+  .replace(/&amp;/g, '&')
+  .replace(/&lt;/g, '<')
+  .replace(/&gt;/g, '>')
+  .replace(/&quot;/g, '"')
+  .replace(/&#39;|&apos;/g, "'")
+  .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+  .replace(/&#x([\da-f]+);/gi, (_, code) => String.fromCodePoint(Number.parseInt(code, 16)));
+
+export const normalizePublicText = (value) => decodeEntities(value)
+  .replace(/<[^>]*>/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+export function splitCanonicalMarkdown(markdown) {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) throw new Error('canonical Markdown is missing frontmatter');
+  return { data: YAML.parse(match[1]), body: markdown.slice(match[0].length) };
+}
+
+function sectionIndex(body) {
+  const tree = unified().use(remarkParse).parse(body);
+  const children = tree.children ?? [];
+  const slugger = new GithubSlugger();
+  const sections = [];
+
+  for (let index = 0; index < children.length; index += 1) {
+    const heading = children[index];
+    if (heading.type !== 'heading') continue;
+    const title = normalizePublicText(toString(heading));
+    const content = [];
+    for (let cursor = index + 1; cursor < children.length; cursor += 1) {
+      const node = children[cursor];
+      if (node.type === 'heading' && node.depth <= heading.depth) break;
+      content.push(node);
+    }
+    sections.push({
+      anchor: slugger.slug(title),
+      title,
+      depth: heading.depth,
+      text: normalizePublicText(content.map((node) => toString(node)).join(' ')),
+    });
+  }
+
+  return {
+    text: normalizePublicText(toString(tree)),
+    sections,
+  };
+}
+
+const markdownUrlForRoute = (route) => `${route.replace(/\/$/, '') || '/index'}.md`;
+
+export async function buildAgentIndex(rootDirectory) {
+  const pages = [];
+  const referencedSourceIds = new Set();
+
+  for (const { route, file, kind } of canonicalContentFiles(rootDirectory)) {
+    const markdown = await readFile(file, 'utf8');
+    const { data, body } = splitCanonicalMarkdown(markdown);
+    const content = sectionIndex(body);
+    const sourceIds = [...(data.sources ?? [])];
+    for (const sourceId of sourceIds) referencedSourceIds.add(sourceId);
+    pages.push({
+      route,
+      markdownUrl: markdownUrlForRoute(route),
+      kind,
+      title: data.title,
+      description: data.description,
+      updatedAt: data.updatedAt,
+      status: data.status,
+      evidence: [...(data.evidence ?? [])],
+      sourceIds,
+      scope: data.navigation?.scope ?? 'handbook',
+      order: data.navigation?.order ?? 0,
+      text: content.text,
+      sections: content.sections,
+    });
+  }
+
+  pages.sort((left, right) => left.route === '/' ? -1 : right.route === '/' ? 1 : left.route.localeCompare(right.route));
+  const publisherById = new Map(sourceRegistry.publishers.map((publisher) => [publisher.id, publisher]));
+  const sources = sourceRegistry.sources
+    .filter((source) => referencedSourceIds.has(source.id))
+    .map((source) => {
+      const publisher = publisherById.get(source.publisher);
+      return {
+        id: source.id,
+        title: source.title,
+        url: source.url,
+        publisher: publisher ? { id: publisher.id, label: publisher.label, domain: publisher.domain } : null,
+        evidence: source.evidence,
+      };
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    schemaVersion: AGENT_INDEX_VERSION,
+    name: 'coding agent tips',
+    discovery: { llms: '/llms.txt', index: '/agent-index.json' },
+    pages,
+    sources,
+  };
+}

--- a/src/agent-index.mjs
+++ b/src/agent-index.mjs
@@ -10,14 +10,14 @@ import { AGENT_INDEX_VERSION } from './agent-index-version.mjs';
 
 export { AGENT_INDEX_VERSION } from './agent-index-version.mjs';
 
-const decodeEntities = (value) => value
-  .replace(/&amp;/g, '&')
-  .replace(/&lt;/g, '<')
-  .replace(/&gt;/g, '>')
-  .replace(/&quot;/g, '"')
-  .replace(/&#39;|&apos;/g, "'")
-  .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
-  .replace(/&#x([\da-f]+);/gi, (_, code) => String.fromCodePoint(Number.parseInt(code, 16)));
+const namedEntities = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+const decodeEntities = (value) => value.replace(/&(?:amp|lt|gt|quot|apos|#39|#\d+|#x[\da-f]+);/gi, (entity) => {
+  const token = entity.slice(1, -1).toLocaleLowerCase();
+  if (token in namedEntities) return namedEntities[token];
+  if (token === '#39') return "'";
+  const codePoint = token.startsWith('#x') ? Number.parseInt(token.slice(2), 16) : Number(token.slice(1));
+  return Number.isSafeInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : entity;
+});
 
 export const normalizePublicText = (value) => decodeEntities(value)
   .replace(/<[^>]*>/g, ' ')

--- a/src/components/StarlightHead.astro
+++ b/src/components/StarlightHead.astro
@@ -3,9 +3,11 @@ import DefaultHead from '@astrojs/starlight/components/Head.astro';
 import { ThemeInitScript } from '@starwind-ui/astro/theme';
 import { ClientRouter } from 'astro:transitions';
 import ThemeBridge from './ThemeBridge.astro';
+import WebMcpSurface from './WebMcpSurface.astro';
 ---
 
 <DefaultHead />
 <ThemeInitScript />
 <ThemeBridge />
+<WebMcpSurface />
 <ClientRouter fallback="swap" />

--- a/src/components/WebMcpSurface.astro
+++ b/src/components/WebMcpSurface.astro
@@ -1,0 +1,3 @@
+<script>
+  import '../webmcp/register';
+</script>

--- a/src/content-manifest.mjs
+++ b/src/content-manifest.mjs
@@ -1,7 +1,8 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(import.meta.dirname, '..');
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 function inlineList(markdown, key) {
   const match = markdown.match(new RegExp(`^${key}:\\s*\\[([^\\]]*)\\]`, 'm'));
@@ -17,8 +18,8 @@ function isDraft(file) {
   return scalar(readFileSync(file, 'utf8'), 'draft') === 'true';
 }
 
-function routeForFile(file) {
-  const contentPath = relative(resolve(root, 'content'), file).replace(/\.md$/, '');
+function routeForFile(file, rootDirectory = root) {
+  const contentPath = relative(resolve(rootDirectory, 'content'), file).replace(/\.md$/, '');
   return `/${contentPath}/`;
 }
 
@@ -28,29 +29,29 @@ function markdownFiles(directory) {
     .map((entry) => resolve(entry.parentPath, entry.name));
 }
 
-function handbookFiles() {
-  return ['handbook', 'guides', 'archive'].flatMap((directory) => markdownFiles(resolve(root, 'content', directory)));
+function handbookFiles(rootDirectory = root) {
+  return ['handbook', 'guides', 'archive'].flatMap((directory) => markdownFiles(resolve(rootDirectory, 'content', directory)));
 }
 
-export function canonicalContentFiles() {
+export function canonicalContentFiles(rootDirectory = root) {
   return [
-    { route: '/', file: resolve(root, 'content/home.md'), kind: 'home' },
-    ...handbookFiles().filter((file) => !isDraft(file)).map((file) => ({
-      route: routeForFile(file),
+    { route: '/', file: resolve(rootDirectory, 'content/home.md'), kind: 'home' },
+    ...handbookFiles(rootDirectory).filter((file) => !isDraft(file)).map((file) => ({
+      route: routeForFile(file, rootDirectory),
       file,
-      kind: relative(resolve(root, 'content'), file).startsWith('archive/') ? 'archive' : 'guide',
+      kind: relative(resolve(rootDirectory, 'content'), file).startsWith('archive/') ? 'archive' : 'guide',
     })),
   ];
 }
 
-export function contentRedirects() {
-  const files = handbookFiles().filter((file) => !isDraft(file));
+export function contentRedirects(rootDirectory = root) {
+  const files = handbookFiles(rootDirectory).filter((file) => !isDraft(file));
   const redirects = {};
   for (const file of files) {
-    const target = routeForFile(file);
+    const target = routeForFile(file, rootDirectory);
     for (const alias of inlineList(readFileSync(file, 'utf8'), 'redirects')) redirects[alias] = target;
   }
-  const home = resolve(root, 'content/home.md');
+  const home = resolve(rootDirectory, 'content/home.md');
   for (const alias of inlineList(readFileSync(home, 'utf8'), 'redirects')) redirects[alias] = '/';
   return redirects;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import { ClientRouter } from 'astro:transitions';
 import SiteHeader from '../components/SiteHeader.astro';
 import ThemeBridge from '../components/ThemeBridge.astro';
 import PublicationEnhancements from '../components/PublicationEnhancements.astro';
+import WebMcpSurface from '../components/WebMcpSurface.astro';
 import { site } from '../site';
 
 interface Props {
@@ -44,6 +45,7 @@ const socialImage = new URL(site.socialImage, Astro.site);
     <title>{title}</title>
     <ThemeInitScript />
     <ThemeBridge />
+    <WebMcpSurface />
     <ClientRouter fallback="swap" />
   </head>
   <body>

--- a/src/pages/agent-index.json.ts
+++ b/src/pages/agent-index.json.ts
@@ -1,0 +1,11 @@
+import { buildAgentIndex } from '../agent-index.mjs';
+
+export async function GET() {
+  const index = await buildAgentIndex(process.cwd());
+  return new Response(`${JSON.stringify(index)}\n`, {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+    },
+  });
+}

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,12 @@
+import { getEntry } from 'astro:content';
+
+export async function GET() {
+  const home = await getEntry('home', 'home');
+  if (!home) return new Response('homepage Markdown is unavailable\n', { status: 404 });
+  return new Response(`${(home.body ?? '').trim()}\n`, {
+    headers: {
+      'content-type': 'text/markdown; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+    },
+  });
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -17,6 +17,8 @@ export async function GET() {
     '',
     '> approved public handbook pages in Markdown for readers, agents, and language models.',
     '',
+    `Structured index: ${new URL('/agent-index.json', site.url).href}`,
+    '',
     ...pages,
     '',
   ].join('\n');

--- a/src/webmcp/register.ts
+++ b/src/webmcp/register.ts
@@ -1,0 +1,78 @@
+import { navigate as astroNavigate } from 'astro:transitions/client';
+import { AGENT_INDEX_VERSION } from '../agent-index-version.mjs';
+import { createHandbookTools } from '../agent-contract.mjs';
+
+type ToolDefinition = ReturnType<typeof createHandbookTools>[number];
+type ModelContext = {
+  registerTool(tool: ToolDefinition, options?: { signal?: AbortSignal }): Promise<void>;
+};
+type RegistrationState = {
+  controller?: AbortController;
+  context?: ModelContext;
+  queue: Promise<void>;
+  lastError?: string;
+};
+
+declare global {
+  interface Document { modelContext?: ModelContext }
+  interface Window { __codingAgentTipsWebMcp?: RegistrationState }
+}
+
+let cachedIndex: unknown;
+async function loadIndex(signal?: AbortSignal) {
+  if (cachedIndex) return cachedIndex;
+  const target = new URL('/agent-index.json', window.location.origin);
+  const response = await fetch(target, { headers: { accept: 'application/json' }, signal });
+  if (!response.ok) throw new Error(`agent index returned ${response.status}`);
+  const index = await response.json();
+  if (index?.schemaVersion !== AGENT_INDEX_VERSION) throw new Error('agent index version mismatch');
+  cachedIndex = index;
+  return index;
+}
+
+async function navigate(target: string) {
+  const destination = new URL(target, window.location.origin);
+  if (destination.origin !== window.location.origin) throw new Error('cross-origin navigation rejected');
+  if (typeof astroNavigate === 'function') {
+    await astroNavigate(destination.href);
+    return;
+  }
+  window.location.assign(destination.href);
+}
+
+const state = window.__codingAgentTipsWebMcp ??= { queue: Promise.resolve() };
+
+async function registerCurrentDocument() {
+  state.controller?.abort();
+  state.controller = undefined;
+  state.context = undefined;
+  state.lastError = undefined;
+
+  const context = document.modelContext;
+  if (!context || typeof context.registerTool !== 'function') return;
+
+  const controller = new AbortController();
+  state.controller = controller;
+  state.context = context;
+  const tools = createHandbookTools({ loadIndex, navigate });
+  try {
+    for (const tool of tools) await context.registerTool(tool, { signal: controller.signal });
+  } catch (error) {
+    controller.abort();
+    if (state.controller === controller) {
+      state.controller = undefined;
+      state.context = undefined;
+      state.lastError = error instanceof Error ? error.message : 'tool registration failed';
+    }
+  }
+}
+
+function setup() {
+  state.queue = state.queue.catch(() => {}).then(registerCurrentDocument);
+}
+
+if (!document.documentElement.hasAttribute('data-webmcp-listener')) {
+  document.documentElement.setAttribute('data-webmcp-listener', '');
+  document.addEventListener('astro:page-load', setup);
+  window.addEventListener('pagehide', () => state.controller?.abort());
+}


### PR DESCRIPTION
## summary

- publish a versioned `/agent-index.json` derived from canonical Markdown and public source metadata
- register five bounded, read-only WebMCP tools through the current `document.modelContext` imperative API
- preserve Astro ClientRouter continuity for validated same-origin tool navigation, with ordinary navigation as progressive fallback
- correct the missing homepage `/index.md` endpoint and connect `/llms.txt` to the structured index
- add contract, lifecycle, unsupported-browser, no-JavaScript, public-text, performance, and route-parity coverage

## interface

- `list_handbook_pages`
- `search_handbook`
- `read_handbook_section`
- `inspect_source`
- `open_handbook_page`

The browser surface is feature-detected, invisible, same-origin, and read-only. It adds no trial token, compatibility shim, analytics, external requests, write operation, or visible public copy.

## verification

- `bun run verify`
- 15 canonical indexed pages
- 65 referenced public sources
- 22,783-byte gzip structured-index payload against a 32 KiB budget
- exact registration replacement across ClientRouter swaps with no duplicate tool names
- public text equality with and without WebMCP support
- no-JavaScript route navigation and static discovery endpoints
- typography, reflow, text spacing, text resize, and axe coverage across 15 routes at 8 required widths

## base

Built from deployed `main` commit `15ff642484a1bfaab8c2a764d4008c6f65d01f1e`.
