### PR TITLE
feat(site): animate a full-page ASCII provider field

### DIFF
--- a/.github/qa/ascii-background.md
+++ b/.github/qa/ascii-background.md
@@ -1,0 +1,46 @@
+# homepage ASCII field review
+
+## scope and source
+
+The implementation lives on `codex/ascii-provider-field`, in the isolated worktree `/private/tmp/coding-agent-tips-ascii`. It starts at `origin/main` commit `259e1d769c1c3005f2cb05c7ea869cc4c4497182`. The retained head of PR #312, `d967e4e988c57c7fffe6d1f0ef6c5dde74726cc6`, is already an ancestor. Its remote branch was deleted after merge. No rejected animation or exception stub exists in this base.
+
+The first implementation commit is `da46325`. Followup refinements start on a resolved frame, handle font loading failure, preserve the immediate no-script reading path, and refine the contrast test's scope. The verified provider assets and original homepage wording remain the source of identity and prose.
+
+## local verification
+
+Passed:
+
+- `bun run check`, with zero errors, warnings, or hints;
+- `bun run build`;
+- `bun run test:site`, including typography ownership and 15 canonical routes;
+- `bun run check:performance`, including media, shared CSS, scripts, and fonts;
+- `bun run check:content`;
+- `bun run check:ui`.
+
+The normal Astro development server was attempted, but the sandbox denied its loopback bind. A Vite static preview of this worktree's production build was available at `http://127.0.0.1:4341/`. Ordinary Chrome UI review covered the homepage at 1440 by 900 and 375 by 812 in both themes, at the top of the page, plus pause and resume. The field visibly moved and formed the source silhouettes. The first review prompted larger, denser glyphs. A startup event race and a deferred-frame cancellation were fixed during review.
+
+`bun run test:a11y` and `bun run test:ascii` were attempted. Their preview ports were denied by the sandbox. Chromium launch was independently blocked by macOS Mach port restrictions. Lighthouse startup also failed. There are no valid Lighthouse, FCP, LCP, CLS, sustained CPU, or complete motion-matrix results from this session. Raw browser DevTools access was declined and was not retried through another route.
+
+## contrast and byte measurements
+
+Reading elements sit on fully opaque canvas or existing component surfaces above the animation. The ten pixel canvas colored extension around prose protects glyph edges. The underlying animated pixels therefore contribute zero to the protected text's background color.
+
+The following are calculations from the paired semantic tokens, independent of animation phase. They are not a substitute for the pending rendered viewport matrix.
+
+| foreground against canvas | light contrast | dark contrast |
+| --- | --- | --- |
+| primary text | 18.88:1 | 18.24:1 |
+| muted text | 7.31:1 | 8.67:1 |
+| accent text | 6.84:1 | 5.01:1 |
+
+The initial audited production builds measured 9,697 bytes of gzipped homepage HTML before and 11,191 bytes after. The new controller and worker were approximately 2,301 and 1,264 bytes gzipped. Subsequent error handling and no-script refinements change these totals slightly. These are delivery size measurements only; browser performance remains unmeasured.
+
+## remaining release work
+
+The new `test:ascii` script covers 36 width, theme, and motion combinations, protected text backgrounds and contrast, full-page axe checks at mobile and desktop sizes, pixel stability under reduced motion and pause, live preference changes, route cleanup, no-script content, and worker transfer fallback.
+
+The `ascii-homepage` CI job runs that matrix and a paired cold mobile Lighthouse comparison with three runs per revision. `audit:ascii` also samples ten seconds of worker frame cost and main thread task duration. Reports and screenshots go to the runner's temporary directory and the `ascii-homepage-qa` artifact. These checks have been authored and syntax checked; they still need execution in a permitted environment.
+
+Before approval, run the new matrix and all existing browser checks, inspect reduced motion in both themes on desktop and mobile, inspect the complete provider sequence, and put actual before and after Lighthouse medians in the PR description. Keep the PR unmerged for Ani's visual review.
+
+The session could push the first signed commit. PR creation was blocked because the connector required native approval while the session's approval policy was `never`. No PR, merge, deployment, or live publication was completed.

--- a/.github/qa/ascii-background.md
+++ b/.github/qa/ascii-background.md
@@ -2,30 +2,37 @@
 
 ## scope and source
 
-The implementation lives on `codex/ascii-provider-field`, in the isolated worktree `/private/tmp/coding-agent-tips-ascii`. It starts at `origin/main` commit `259e1d769c1c3005f2cb05c7ea869cc4c4497182`. The retained head of PR #312, `d967e4e988c57c7fffe6d1f0ef6c5dde74726cc6`, is already an ancestor. Its remote branch was deleted after merge. No rejected animation or exception stub exists in this base.
+Draft [PR #315](https://github.com/anipotts/coding-agent-tips/pull/315) uses `codex/ascii-provider-field`. The September 7 repair worktree is `/Users/anipotts/.codex/worktrees/ascii-repair/coding-agent-tips`. Its signed merge `82b9e77` integrates current main `7557555`, including PR #316's navigation and controls. The design authority from PR #312 is already in main. Editorial work remains separate.
 
-The first implementation commit is `da46325`. Followup refinements start on a resolved frame, handle font loading failure, preserve the immediate no-script reading path, and refine the contrast test's scope. The verified provider assets and original homepage wording remain the source of identity and prose.
+The field uses the verified provider assets to generate compact masks at build time. One canvas follows a continuous search, gather, resolve, and disperse sequence. OffscreenCanvas renders in a worker at a capped 30 fps on desktop and 24 fps on mobile. Particle count, resolution, and device pixel ratio are bounded. Hidden tabs and pause stop scheduling; reduced motion draws one resolved Codex frame. The fallback also draws one static frame. No animation library or runtime image download is required.
 
-## local verification
+The single approved exception in `design.md` describes the implementation, its reading surfaces, motion controls, and verification requirements.
 
-Passed:
+## verification on September 7
+
+The initial September 5 environment blocked browser testing. Those historical restrictions no longer apply. The previous CI run `33990903386` stopped because its runner shut down during the matrix. The new run [34143213189](https://github.com/anipotts/coding-agent-tips/actions/runs/34143213189) completed the matrix and exposed the separate Lighthouse gate described below.
+
+The following checks passed locally on the integrated animation tree:
 
 - `bun run check`, with zero errors, warnings, or hints;
 - `bun run build`;
-- `bun run test:site`, including typography ownership and 15 canonical routes;
-- `bun run check:performance`, including media, shared CSS, scripts, and fonts;
-- `bun run check:content`;
-- `bun run check:ui`.
+- `bun run test:site`, including 15 canonical routes;
+- `bun run check:performance`, covering delivery size and asset budgets;
+- `bun run check:content` and `bun run check:ui`;
+- `bun run test:ascii`, covering all 36 width, theme, and motion combinations;
+- `bun run test:a11y`, including typography, reflow, text spacing, text resize, and axe across 15 routes at eight widths in both themes;
+- WebMCP, navigation, and normal development search checks;
+- `bun run test:audit-preview`, including compressed response parity.
 
-The normal Astro development server was attempted, but the sandbox denied its loopback bind. A Vite static preview of this worktree's production build was available at `http://127.0.0.1:4341/`. Ordinary Chrome UI review covered the homepage at 1440 by 900 and 375 by 812 in both themes, at the top of the page, plus pause and resume. The field visibly moved and formed the source silhouettes. The first review prompted larger, denser glyphs. A startup event race and a deferred-frame cancellation were fixed during review.
+The matrix checks protected text backgrounds and contrast, full-page axe results at mobile and desktop sizes, pixel stability under reduced motion and pause, live preference changes, route cleanup, no-script content, and worker transfer fallback. Widths are 320, 375, 768, 942, 959, 960, 1024, 1191, and 1440 pixels in both themes and motion preferences. Progress and partial results are saved after each combination so an interrupted runner retains useful evidence.
 
-`bun run test:a11y` and `bun run test:ascii` were attempted. Their preview ports were denied by the sandbox. Chromium launch was independently blocked by macOS Mach port restrictions. Lighthouse startup also failed. There are no valid Lighthouse, FCP, LCP, CLS, sustained CPU, or complete motion-matrix results from this session. Raw browser DevTools access was declined and was not retried through another route.
+Manual review used the normal Astro development server at `http://127.0.0.1:4351/`, at 1440 by 900 and 375 by 812 in light and dark themes. The review included the moving field and recognizable provider forms. Full-page reduced-motion captures at 1440 and 375 pixels were also inspected in both themes. The heading, prose, guide cards, links, and footer retain readable surfaces.
 
-## contrast and byte measurements
+A full verification run exposed a timing race in the existing WebMCP test: Astro adds the page title to its screen reader route announcer after navigation. The test now excludes that transient announcement through a test-only style in both compared pages; its strict public-text equality and registration assertions remain intact. No production announcement behavior changes.
 
-Reading elements sit on fully opaque canvas or existing component surfaces above the animation. The ten pixel canvas colored extension around prose protects glyph edges. The underlying animated pixels therefore contribute zero to the protected text's background color.
+## contrast
 
-The following are calculations from the paired semantic tokens, independent of animation phase. They are not a substitute for the pending rendered viewport matrix.
+Reading elements sit on fully opaque canvas or component surfaces above the animation. A ten pixel canvas colored extension protects prose glyph edges. Animated pixels contribute zero to the protected text background, independent of phase. The rendered matrix verifies the computed surfaces and contrast.
 
 | foreground against canvas | light contrast | dark contrast |
 | --- | --- | --- |
@@ -33,14 +40,50 @@ The following are calculations from the paired semantic tokens, independent of a
 | muted text | 7.31:1 | 8.67:1 |
 | accent text | 6.84:1 | 5.01:1 |
 
-The initial audited production builds measured 9,697 bytes of gzipped homepage HTML before and 11,191 bytes after. The new controller and worker were approximately 2,301 and 1,264 bytes gzipped. Subsequent error handling and no-script refinements change these totals slightly. These are delivery size measurements only; browser performance remains unmeasured.
+## paired performance measurements
 
-## remaining release work
+Both sets use three cold homepage runs per revision with Lighthouse's default mobile simulation. The unchanged baseline is main `7557555`; the candidate is the integrated animation tree at `82b9e77`. Subsequent diagnostic changes affect test scripts and this review document.
 
-The new `test:ascii` script covers 36 width, theme, and motion combinations, protected text backgrounds and contrast, full-page axe checks at mobile and desktop sizes, pixel stability under reduced motion and pause, live preference changes, route cleanup, no-script content, and worker transfer fallback.
+| median metric | local baseline | local animation | Linux CI baseline | Linux CI animation |
+| --- | ---: | ---: | ---: | ---: |
+| Lighthouse performance | 96 | 96 | 97 | 97 |
+| FCP, ms | 2036.35 | 2108.03 | 1675.31 | 1674.32 |
+| LCP, ms | 2486.35 | 2487.72 | 2347.86 | 2342.56 |
+| TBT, ms | 0 | 0 | 0 | 0 |
+| CLS | 0.000971 | 0.000971 | 0.000971 | 0.000971 |
+| transferred bytes | 252264 | 256974 | 252622 | 257357 |
 
-The `ascii-homepage` CI job runs that matrix and a paired cold mobile Lighthouse comparison with three runs per revision. `audit:ascii` also samples ten seconds of worker frame cost and main thread task duration. Reports and screenshots go to the runner's temporary directory and the `ascii-homepage-qa` artifact. These checks have been authored and syntax checked; they still need execution in a permitted environment.
+The animation adds approximately 4.7 KB to the measured transfer. These samples show timing variation; they establish neither a speed improvement nor a general absence of regressions.
 
-Before approval, run the new matrix and all existing browser checks, inspect reduced motion in both themes on desktop and mobile, inspect the complete provider sequence, and put actual before and after Lighthouse medians in the PR description. Keep the PR unmerged for Ani's visual review.
+Ten seconds of desktop worker sampling measured 271 frames locally with frame p50 1.5 ms, p95 1.9 ms, and 5.55 ms of main thread tasks. Linux CI measured 300 frames with p50 3.2 ms, p95 3.4 ms, and 9.18 ms of main thread tasks. These are instrumented Chromium samples, not whole-device power measurements.
 
-The session could push the first signed commit. PR creation was blocked because the connector required native approval while the session's approval policy was `never`. No PR, merge, deployment, or live publication was completed.
+The absolute performance gate remains **99**, TBT below 100 ms, CLS below 0.05, and worker frame p95 at most 16 ms. Both baseline and candidate miss the score gate through the original HTTP/1.1 preview. A failing baseline grants no waiver. It now records revisions, runtime provenance, medians, deltas, and separate baseline and candidate failures, and rejects missing worker samples.
+
+Font discovery and the protocol used by the preview explain the initial investigation. The retained production repair preloads the original Instrument Sans Latin font in the homepage head. CSS and typography remain unchanged. CSS/font embedding and broad runtime bundling were measured and rejected; they are absent from the final diff.
+
+CI reports and screenshots are retained in the [ASCII QA artifact](https://github.com/anipotts/coding-agent-tips/actions/runs/34143213189/artifacts/10026737446). Local initial comparison reports are in `/private/tmp/ascii-repair-audit`. The local matrix uses the system temporary `ascii-homepage-qa` directory.
+
+## production protocol comparison
+
+On September 7, `curl` independently confirmed that `https://agents.anipotts.com` serves HTTP/2. Vite preview serves HTTP/1.1. Default Lighthouse network simulation produced a materially different result for the same built files under those two protocols.
+
+A paired HTTP/2 comparison of main `7557555` and the integrated animation with the original-font preload produced these medians, with all three runs in each group scoring 100:
+
+| metric | baseline | animation and font preload |
+| --- | ---: | ---: |
+| Lighthouse performance | 100 | 100 |
+| FCP, ms | 1430.84 | 1280.81 |
+| LCP, ms | 1506.11 | 1505.81 |
+| TBT, ms | 0 | 0 |
+| CLS | 0.026217 | 0.000971 |
+| transferred bytes | 241019 | 245219 |
+
+The initial protocol comparison artifacts are in `/private/tmp/ascii-http2-audit`. Ten seconds of runtime sampling measured 273 frames, worker p50 1.4 ms and p95 3.0 ms, with 6.15 ms of main thread tasks. CLS varied between baseline runs; the paired results are observations, not a general claim about every device or load.
+
+Both `audit:ascii` and `audit:performance` now use `scripts/lib/http2-preview.mjs` for Lighthouse. It forwards Vite responses through loopback HTTP/2 without changing their body, status, compression, or cache policy. A regression test verifies byte and header parity, including a compressed 404 response. Each Lighthouse run must report protocol `h2`. The certificate is generated temporarily for loopback use and removed on shutdown; the browser exception is restricted to insecure localhost.
+
+The Lighthouse version, mobile simulation, three-run medians, score 99, TBT, CLS, and worker thresholds remain unchanged. Reports retain the measured revisions and homepage HTML hashes. The original HTTP/1.1 comparison is retained above so the protocol correction is explicit.
+
+## review state
+
+The animation is prepared for visual review. The production protocol comparison meets the unchanged Lighthouse gate. Final signed-head CI status is reported with the PR receipt. Keep PR #315 unmerged, as requested by Ani. A local preview, passing size budgets, and passing motion checks do not establish a production release.

--- a/.github/qa/ascii-background.md
+++ b/.github/qa/ascii-background.md
@@ -61,7 +61,7 @@ The absolute performance gate remains **99**, TBT below 100 ms, CLS below 0.05, 
 
 Font discovery and the protocol used by the preview explain the initial investigation. The retained production repair preloads the original Instrument Sans Latin font in the homepage head. CSS and typography remain unchanged. CSS/font embedding and broad runtime bundling were measured and rejected; they are absent from the final diff.
 
-CI reports and screenshots are retained in the [ASCII QA artifact](https://github.com/anipotts/coding-agent-tips/actions/runs/34143213189/artifacts/10026737446). Local initial comparison reports are in `/private/tmp/ascii-repair-audit`. The local matrix uses the system temporary `ascii-homepage-qa` directory.
+CI reports and screenshots are retained in the [ASCII QA artifact](https://github.com/anipotts/coding-agent-tips/actions/runs/34143213189). Local initial comparison reports are in `/private/tmp/ascii-repair-audit`. The local matrix uses the system temporary `ascii-homepage-qa` directory.
 
 ## production protocol comparison
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,6 +69,41 @@ jobs:
       - name: scan mobile and desktop accessibility
         run: bun run test:a11y
 
+  ascii-homepage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.4"
+      - run: bun install --frozen-lockfile
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run build
+      - name: verify ASCII lifecycle, contrast, and motion matrix
+        run: bun run test:ascii
+        env:
+          ASCII_QA_DIR: ${{ runner.temp }}/ascii-qa
+      - name: build the exact comparison base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        run: |
+          git worktree add --detach "$RUNNER_TEMP/ascii-baseline" "$BASE_SHA"
+          ln -s "$GITHUB_WORKSPACE/node_modules" "$RUNNER_TEMP/ascii-baseline/node_modules"
+          cd "$RUNNER_TEMP/ascii-baseline"
+          bun run build
+      - name: compare cold homepage Lighthouse and sustained worker cost
+        run: bun run audit:ascii "$RUNNER_TEMP/ascii-baseline"
+        env:
+          ASCII_QA_DIR: ${{ runner.temp }}/ascii-qa
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: ascii-homepage-qa
+          path: ${{ runner.temp }}/ascii-qa
+
   handbook:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,6 +82,8 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
       - run: bun run build
+      - name: verify audit transport preserves publication responses
+        run: bun run test:audit-preview
       - name: verify ASCII lifecycle, contrast, and motion matrix
         run: bun run test:ascii
         env:

--- a/design.md
+++ b/design.md
@@ -95,7 +95,7 @@ Compare matching routes, viewport sizes, themes, scroll positions, focus states,
 
 The homepage introduces one clear thesis and routes the reader into the handbook. Its hierarchy comes from a strong opening, compact guide groups, and direct shared-guide links.
 
-Keep the first screen legible without decorative hero art. Use open rows and restrained cards only where a group needs a boundary. Provider groups may share a grid because they have the same conceptual structure. Shared guides remain a simple publication list.
+Keep the first screen legible. The homepage ASCII field follows the scoped exception under motion and reduced motion. Use open rows and restrained cards only where a group needs a boundary. Provider groups may share a grid because they have the same conceptual structure. Shared guides remain a simple publication list.
 
 ### provider guide pages
 
@@ -364,6 +364,22 @@ Default to stillness. The interface continuity token is `160ms` with `cubic-bezi
 Use motion to preserve spatial understanding when provider state moves, a sidebar changes width, a disclosure opens, or a menu appears. Client route swaps remain immediate. Do not add page crossfades, scroll reveals, parallax, simulated typing, pulsing status, bouncing controls, or animation that delays reading.
 
 Under `prefers-reduced-motion: reduce`, remove nonessential transition and animation duration, disable smooth scrolling, and preserve the final state without an intermediate effect. No information, focus change, or control outcome may depend on motion.
+
+### approved exception: homepage ASCII field
+
+Ani explicitly requested a full viewport cobalt ASCII animation for the homepage on September 5, 2026. This is the single scoped exception to stillness, ambient hero art, decorative provider scale, and cobalt used solely for interface state. The reader outcome is an identifiable introduction to the three provider families while the complete handbook remains immediately readable and usable.
+
+The field searches in flowing ribbons, gathers into a verified provider silhouette, holds its form with small internal movement, and releases into the next current. Codex, Claude Code, and Grok receive equal time. The shape sequence repeats every 66 seconds; independent flow and glyph phases continue across that boundary. Sample the registered local product assets at build time. Preserve their source identity in `src/site.ts`; the animation carries no claim of endorsement, agent activity, or product performance.
+
+`AsciiBackground.astro` owns this homepage enhancement and its explicit navigation lifecycle. `src/lib/ascii/` owns build time silhouette sampling, the shared renderer, and its worker. Starwind owns the visible pause button. The glyph atlas inherits cobalt and IBM Plex Mono from the existing color and typography authorities. No animation dependency, terminal chrome, typing simulation, ticker, scroll effect, or runtime image fetch is permitted.
+
+The canvas sits behind the entire homepage and stays fixed to the viewport. Desktop composition leaves room for a large mark beside the title. Narrow layouts reserve a stage above the title. Opaque canvas colored reading surfaces protect headings, paragraphs, guide groups, and footer independently of animation phase. Existing header and overlay surfaces preserve control contrast. These reading surfaces may extend by ten pixels to protect glyph edges; this is occlusion using the canvas color, with no ornamental shadow or elevation.
+
+Use a worker and OffscreenCanvas for continuous drawing, a cached glyph atlas, at most 3,000 desktop or 1,500 mobile characters, at most 30 desktop or 24 mobile frames per second, and a backing store capped at 2.5 million pixels and 1.5 device pixels per CSS pixel. Initialization yields through two paints and an idle callback. Hidden documents suspend the loop. Pause persists when storage is available. Route departure terminates the worker and removes observers and listeners. Unsupported worker or canvas transfer behavior renders one static frame where possible; ordinary content survives failed enhancement.
+
+Reduced motion renders a stable Codex frame and schedules no animation timer. Live preference changes stop animation as well. Theme and viewport changes may repaint that same frame. A reader's pause freezes the current frame and resumes from that point. The pause control stays available during animation and remains hidden when the system requires stillness.
+
+Protect this exception with `bun run test:ascii`, the full publication checks, a paired cold homepage Lighthouse comparison, and actual light and dark visual review at desktop and mobile widths. Measure text contrast against the opaque foreground surfaces throughout the page. Guide routes keep their existing motion policy. This exception replaces the rejected small relay and static logo crossfade concepts; it authorizes this field only.
 
 ## responsive contracts
 

--- a/design.md
+++ b/design.md
@@ -445,6 +445,8 @@ Do not hide page overflow to conceal a broken component. Repair it or give a gen
 
 Keep static HTML, ordinary URLs, external shared CSS, and the existing Astro `ClientRouter`. Do not add React, global hydration, a service worker, analytics, another icon kit, or a third-party runtime for visual refinement.
 
+The homepage preloads its existing Latin Instrument Sans font so the heading font is discovered with the document. Cold Lighthouse audits use a loopback HTTP/2 preview, matching the production CDN, and pinned Chromium with the default mobile simulation. The proxy preserves the built response bytes and cache headers and must prove that HTTP/2 was negotiated. Keep the homepage score gate at 99, with the existing layout shift and blocking time limits. Protocol changes must be recorded alongside paired baseline and candidate measurements.
+
 Prefer CSS and semantic HTML for presentation. Prefetch likely provider and chapter destinations on intent; do not prefetch every page, citation, hash, image, or embed.
 
 Use the established budgets for guide HTML, shared CSS, Starwind runtime JavaScript, fonts, and duplicate component code. Keep the console free of errors and actionable warnings. A visual flourish does not justify route latency, layout shift, input delay, privacy cost, or another failure mode.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "audit:performance": "node scripts/audit-performance.mjs",
     "preview": "node node_modules/astro/bin/astro.mjs preview",
     "sync:readme": "bun scripts/sync-readme.ts",
-    "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:agent && bun run test:navigation && bun run test:dev-search && bun run test:a11y"
+    "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:agent && bun run test:navigation && bun run test:dev-search && bun run test:a11y && bun run test:ascii",
+    "test:ascii": "node scripts/test-ascii.mjs",
+    "audit:ascii": "node scripts/audit-ascii-homepage.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "preview": "node node_modules/astro/bin/astro.mjs preview",
     "sync:readme": "bun scripts/sync-readme.ts",
     "verify": "bun run check:content && bun run check:ui && bun run build && bun run test:site && bun run check:performance && bun run test:agent && bun run test:navigation && bun run test:dev-search && bun run test:a11y && bun run test:ascii",
+    "test:audit-preview": "node --test scripts/lib/http2-preview.test.mjs",
     "test:ascii": "node scripts/test-ascii.mjs",
     "audit:ascii": "node scripts/audit-ascii-homepage.mjs"
   },

--- a/scripts/audit-ascii-homepage.mjs
+++ b/scripts/audit-ascii-homepage.mjs
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { chromium } from '@playwright/test';
+import lighthouse from 'lighthouse';
+import * as chromeLauncher from 'chrome-launcher';
+
+const output = process.env.ASCII_QA_DIR || path.join(os.tmpdir(), 'ascii-homepage-qa');
+await mkdir(output, { recursive: true });
+const baseline = process.argv[2];
+if (!baseline) throw Error('Pass a built baseline checkout path');
+const reports = {};
+for (const [label, cwd] of [['before', path.resolve(baseline)], ['after', process.cwd()]]) {
+  const server = spawn(process.execPath, [path.resolve('node_modules/vite/bin/vite.js'), 'preview', '--host', '127.0.0.1', '--port', '4178', '--strictPort'], { cwd, stdio: 'inherit' });
+  const exit = once(server, 'exit');
+  try {
+    for (let i=0;i<50;i++) { try { if ((await fetch('http://127.0.0.1:4178/')).ok) break; } catch {} if(i===49) throw Error('preview unavailable'); await new Promise(r=>setTimeout(r,200)); }
+    const runs = [];
+    for (let i=1;i<=3;i++) {
+      const chrome = await chromeLauncher.launch({ chromePath: chromium.executablePath(), chromeFlags: ['--headless=new','--no-sandbox'] });
+      try {
+        const r = await lighthouse('http://127.0.0.1:4178/', { port: chrome.port, onlyCategories: ['performance'], output: 'json', logLevel: 'silent' });
+        await writeFile(path.join(output, `${label}-lighthouse-${i}.json`), r.report);
+        const a = r.lhr.audits;
+        runs.push({ score: r.lhr.categories.performance.score * 100, fcp: a['first-contentful-paint'].numericValue, lcp: a['largest-contentful-paint'].numericValue, tbt: a['total-blocking-time'].numericValue, cls: a['cumulative-layout-shift'].numericValue, bytes: a['total-byte-weight'].numericValue });
+      } finally { await chrome.kill(); }
+    }
+    reports[label] = { runs, median: Object.fromEntries(Object.keys(runs[0]).map(k=>[k,runs.map(r=>r[k]).sort((a,b)=>a-b)[1]])) };
+    if (label === 'after') {
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage({viewport:{width:1440,height:900}}); await page.goto('http://127.0.0.1:4178/');
+        await page.waitForFunction(()=>document.querySelector('.ascii-background')?.dataset.motion==='running');
+        const worker = page.workers()[0];
+        await worker.evaluate(() => {
+          self.frameCosts = [];
+          const original = self.setTimeout.bind(self);
+          self.setTimeout = (fn, delay, ...args) => original(() => { const start=performance.now(); fn(...args); self.frameCosts.push(performance.now()-start); }, delay);
+        });
+        const cdp = await page.context().newCDPSession(page); await cdp.send('Performance.enable');
+        const metrics = async () => Object.fromEntries((await cdp.send('Performance.getMetrics')).metrics.map(m=>[m.name,m.value]));
+        const start = await metrics(); await page.waitForTimeout(10000); const end=await metrics();
+        const costs=await worker.evaluate(()=>self.frameCosts);
+        costs.sort((a,b)=>a-b);
+        reports.runtime={ seconds:10,frames:costs.length,workerFrameP50Ms:costs[Math.floor(costs.length*.5)],workerFrameP95Ms:costs[Math.floor(costs.length*.95)],mainThreadTaskMs:(end.TaskDuration-start.TaskDuration)*1000 };
+      } finally {await browser.close();}
+    }
+  } finally { server.kill('SIGTERM'); await exit; }
+}
+await writeFile(path.join(output,'performance.json'),JSON.stringify(reports,null,2));
+console.log(JSON.stringify(reports,null,2));
+if (reports.after.median.score < 99 || reports.after.median.tbt >= 100 || reports.after.median.cls >= .05) throw Error('homepage Lighthouse budget regressed');
+if (reports.runtime.workerFrameP95Ms > 16) throw Error('worker frame budget exceeded');

--- a/scripts/audit-ascii-homepage.mjs
+++ b/scripts/audit-ascii-homepage.mjs
@@ -1,17 +1,29 @@
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import os from 'node:os';
 import { chromium } from '@playwright/test';
 import lighthouse from 'lighthouse';
 import * as chromeLauncher from 'chrome-launcher';
+import { startHttp2Preview, requireHttp2 } from './lib/http2-preview.mjs';
 
 const output = process.env.ASCII_QA_DIR || path.join(os.tmpdir(), 'ascii-homepage-qa');
 await mkdir(output, { recursive: true });
 const baseline = process.argv[2];
 if (!baseline) throw Error('Pass a built baseline checkout path');
-const reports = {};
+const revision = cwd => execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim();
+const htmlDigest = async cwd => createHash('sha256').update(await readFile(path.join(cwd, 'dist/index.html'))).digest('hex');
+const reports = { provenance: {
+  measuredAt: new Date().toISOString(),
+  baseline: revision(path.resolve(baseline)), candidate: revision(process.cwd()),
+  baselineHtmlSha256: await htmlDigest(path.resolve(baseline)), candidateHtmlSha256: await htmlDigest(process.cwd()),
+  node: process.version, platform: process.platform, browser: chromium.executablePath(),
+  profile: 'Lighthouse default cold mobile simulation over HTTP/2; three runs per revision',
+} };
+const auditPreview = await startHttp2Preview(4178);
+try {
 for (const [label, cwd] of [['before', path.resolve(baseline)], ['after', process.cwd()]]) {
   const server = spawn(process.execPath, [path.resolve('node_modules/vite/bin/vite.js'), 'preview', '--host', '127.0.0.1', '--port', '4178', '--strictPort'], { cwd, stdio: 'inherit' });
   const exit = once(server, 'exit');
@@ -19,9 +31,11 @@ for (const [label, cwd] of [['before', path.resolve(baseline)], ['after', proces
     for (let i=0;i<50;i++) { try { if ((await fetch('http://127.0.0.1:4178/')).ok) break; } catch {} if(i===49) throw Error('preview unavailable'); await new Promise(r=>setTimeout(r,200)); }
     const runs = [];
     for (let i=1;i<=3;i++) {
-      const chrome = await chromeLauncher.launch({ chromePath: chromium.executablePath(), chromeFlags: ['--headless=new','--no-sandbox'] });
+      console.log(`auditing ${label} cold mobile run ${i}/3`);
+      const chrome = await chromeLauncher.launch({ chromePath: chromium.executablePath(), chromeFlags: ['--headless=new','--no-sandbox','--allow-insecure-localhost'] });
       try {
-        const r = await lighthouse('http://127.0.0.1:4178/', { port: chrome.port, onlyCategories: ['performance'], output: 'json', logLevel: 'silent' });
+        const r = await lighthouse(`${auditPreview.origin}/`, { port: chrome.port, onlyCategories: ['performance'], output: 'json', logLevel: 'silent' });
+        requireHttp2(r.lhr);
         await writeFile(path.join(output, `${label}-lighthouse-${i}.json`), r.report);
         const a = r.lhr.audits;
         runs.push({ score: r.lhr.categories.performance.score * 100, fcp: a['first-contentful-paint'].numericValue, lcp: a['largest-contentful-paint'].numericValue, tbt: a['total-blocking-time'].numericValue, cls: a['cumulative-layout-shift'].numericValue, bytes: a['total-byte-weight'].numericValue });
@@ -43,13 +57,32 @@ for (const [label, cwd] of [['before', path.resolve(baseline)], ['after', proces
         const metrics = async () => Object.fromEntries((await cdp.send('Performance.getMetrics')).metrics.map(m=>[m.name,m.value]));
         const start = await metrics(); await page.waitForTimeout(10000); const end=await metrics();
         const costs=await worker.evaluate(()=>self.frameCosts);
+        if (!costs.length || costs.some(cost => !Number.isFinite(cost))) throw Error('worker timing sample is empty or invalid');
         costs.sort((a,b)=>a-b);
         reports.runtime={ seconds:10,frames:costs.length,workerFrameP50Ms:costs[Math.floor(costs.length*.5)],workerFrameP95Ms:costs[Math.floor(costs.length*.95)],mainThreadTaskMs:(end.TaskDuration-start.TaskDuration)*1000 };
       } finally {await browser.close();}
     }
   } finally { server.kill('SIGTERM'); await exit; }
 }
+// Keep the existing absolute gates. A baseline miss is context, never a waiver.
+const budgetFailures = ({ score, tbt, cls }) => [
+  ...(score < 99 ? [`performance score ${score} is below 99`] : []),
+  ...(tbt >= 100 ? [`TBT ${tbt}ms is not below 100ms`] : []),
+  ...(cls >= .05 ? [`CLS ${cls} is not below 0.05`] : []),
+];
+reports.budget = {
+  baselineFailures: budgetFailures(reports.before.median),
+  candidateFailures: budgetFailures(reports.after.median),
+  workerFailures: reports.runtime.workerFrameP95Ms > 16 ? ['worker frame p95 exceeds 16ms'] : [],
+};
+reports.delta = Object.fromEntries(Object.keys(reports.after.median).map(key => [key, reports.after.median[key] - reports.before.median[key]]));
 await writeFile(path.join(output,'performance.json'),JSON.stringify(reports,null,2));
 console.log(JSON.stringify(reports,null,2));
-if (reports.after.median.score < 99 || reports.after.median.tbt >= 100 || reports.after.median.cls >= .05) throw Error('homepage Lighthouse budget regressed');
-if (reports.runtime.workerFrameP95Ms > 16) throw Error('worker frame budget exceeded');
+if (reports.budget.candidateFailures.length || reports.budget.workerFailures.length) {
+  const baselineContext = reports.budget.baselineFailures.length
+    ? `Unchanged baseline also misses the absolute budget: ${reports.budget.baselineFailures.join('; ')}. This alone does not establish an animation regression.`
+    : 'Unchanged baseline meets the absolute homepage budget.';
+  throw Error(`Homepage budget failed: ${[...reports.budget.candidateFailures, ...reports.budget.workerFailures].join('; ')}. ${baselineContext}`);
+}
+
+} finally { await auditPreview.close(); }

--- a/scripts/audit-performance.mjs
+++ b/scripts/audit-performance.mjs
@@ -7,6 +7,7 @@ import process from 'node:process';
 import { chromium } from '@playwright/test';
 import * as chromeLauncher from 'chrome-launcher';
 import lighthouse from 'lighthouse';
+import { startHttp2Preview, requireHttp2 } from './lib/http2-preview.mjs';
 
 const root = process.cwd();
 const previewPort = 4176;
@@ -32,6 +33,7 @@ const failures = [];
 let server;
 let serverExit;
 let browser;
+let auditPreview;
 
 const median = (values) => [...values].sort((left, right) => left - right)[Math.floor(values.length / 2)];
 const metricsFor = (lhr) => ({
@@ -55,17 +57,19 @@ try {
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
 
+  auditPreview = await startHttp2Preview(previewPort);
   for (const page of pages) {
     for (let run = 1; run <= 3; run += 1) {
       console.log(`auditing ${page.id} cold mobile run ${run}/3`);
-      const chrome = await chromeLauncher.launch({ chromeFlags: ['--headless=new', '--no-sandbox'] });
+      const chrome = await chromeLauncher.launch({ chromePath: chromium.executablePath(), chromeFlags: ['--headless=new', '--no-sandbox', '--allow-insecure-localhost'] });
       try {
-        const result = await lighthouse(`${origin}${page.route}`, {
+        const result = await lighthouse(`${auditPreview.origin}${page.route}`, {
           port: chrome.port,
           onlyCategories: ['performance'],
           output: 'json',
           logLevel: 'silent',
         });
+        requireHttp2(result.lhr);
         const reportPath = path.join(outputDirectory, `${page.id}-${run}.json`);
         await writeFile(reportPath, result.report);
         audits.push({ page: page.id, run, ...metricsFor(result.lhr), reportPath });
@@ -155,13 +159,14 @@ try {
   if (medians.home.score < 99) failures.push(`home: median Lighthouse score ${medians.home.score} did not preserve the 100-class baseline`);
   if (warmSwitch.inp >= 100) failures.push(`warm provider switch: ${warmSwitch.inp}ms is not below 100ms`);
 
-  const summary = { generatedAt: new Date().toISOString(), outputDirectory, medians, warmSwitch, audits, failures };
+  const summary = { protocol: 'h2', profile: 'Lighthouse default cold mobile simulation', generatedAt: new Date().toISOString(), outputDirectory, medians, warmSwitch, audits, failures };
   await writeFile(path.join(outputDirectory, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
   console.table(medians);
   console.log(`warm provider switch INP: ${warmSwitch.inp}ms`);
   console.log(`audit artifacts: ${outputDirectory}`);
 } finally {
   await browser?.close();
+  await auditPreview?.close();
   if (server && server.exitCode === null && server.signalCode === null) server.kill('SIGTERM');
   if (serverExit) await serverExit;
   for (let attempt = 0; attempt < 40; attempt += 1) {

--- a/scripts/check-ui-ownership.mjs
+++ b/scripts/check-ui-ownership.mjs
@@ -63,6 +63,8 @@ for (const [file, source] of repositoryText) {
 }
 
 const allowedControllers = new Set([
+  // Homepage canvas lifecycle: approved exception in design.md.
+  'src/components/AsciiBackground.astro',
   'src/components/PublicationEnhancements.astro',
   'src/components/StarlightPageSidebar.astro',
   'src/components/StarlightPageTitle.astro',

--- a/scripts/lib/http2-preview.mjs
+++ b/scripts/lib/http2-preview.mjs
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import http from 'node:http';
+import http2 from 'node:http2';
+import os from 'node:os';
+import path from 'node:path';
+
+const hopHeaders = new Set(['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade', 'http2-settings']);
+const forwardedHeaders = headers => Object.fromEntries(Object.entries(headers).filter(([name]) => !name.startsWith(':') && !hopHeaders.has(name)));
+
+/** Preserve Vite's response bytes and headers while matching the live CDN protocol. */
+export async function startHttp2Preview(upstreamPort) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'handbook-audit-tls-'));
+  const sessions = new Set();
+  let server;
+  const close = async () => {
+    for (const session of sessions) session.destroy();
+    if (server?.listening) await new Promise(resolve => server.close(resolve));
+    await rm(directory, { recursive: true, force: true });
+  };
+  try {
+    // One-day, loopback-only test certificate; never published or stored in reports.
+    execFileSync('openssl', ['req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+      '-keyout', path.join(directory, 'key.pem'), '-out', path.join(directory, 'cert.pem'),
+      '-days', '1', '-subj', '/CN=localhost', '-addext', 'subjectAltName=DNS:localhost,IP:127.0.0.1'], { stdio: 'ignore' });
+    server = http2.createSecureServer({
+      key: await readFile(path.join(directory, 'key.pem')),
+      cert: await readFile(path.join(directory, 'cert.pem')),
+    }, (request, response) => {
+      const upstream = http.request({ hostname: '127.0.0.1', port: upstreamPort,
+        path: request.url, method: request.method, headers: forwardedHeaders(request.headers) }, result => {
+        response.writeHead(result.statusCode, forwardedHeaders(result.headers));
+        result.pipe(response);
+      });
+      upstream.on('error', () => { if (!response.headersSent) response.writeHead(502); response.end(); });
+      response.on('close', () => upstream.destroy());
+      request.pipe(upstream);
+    });
+    server.on('session', session => { sessions.add(session); session.on('close', () => sessions.delete(session)); });
+    await new Promise((resolve, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', resolve); });
+    return { origin: `https://127.0.0.1:${server.address().port}`, close };
+  } catch (error) { await close(); throw error; }
+}
+
+export function requireHttp2(lhr) {
+  const document = lhr.audits['network-requests'].details.items.find(item => item.resourceType === 'Document');
+  if (document?.protocol !== 'h2') throw new Error(`Expected HTTP/2 in Lighthouse, received ${document?.protocol ?? 'no document request'}`);
+}

--- a/scripts/lib/http2-preview.test.mjs
+++ b/scripts/lib/http2-preview.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import http2 from 'node:http2';
+import { gzipSync } from 'node:zlib';
+import { test } from 'node:test';
+import { startHttp2Preview } from './http2-preview.mjs';
+
+test('HTTP/2 audit proxy preserves response bytes, status, and cache headers', async () => {
+  const body = gzipSync(Buffer.from('<!doctype html><title>unchanged publication</title>'));
+  const upstream = http.createServer((request, response) => {
+    assert.equal(request.url, '/missing?query=kept');
+    response.writeHead(404, {
+      'content-type': 'text/html; charset=utf-8', 'content-encoding': 'gzip',
+      'content-length': body.length, 'cache-control': 'public, max-age=60',
+    });
+    response.end(body);
+  });
+  await new Promise(resolve => upstream.listen(0, '127.0.0.1', resolve));
+  let preview, client;
+  try {
+    preview = await startHttp2Preview(upstream.address().port);
+    client = http2.connect(preview.origin, { rejectUnauthorized: false });
+    const request = client.request({ ':path': '/missing?query=kept' });
+    const chunks = [];
+    let headers;
+    await new Promise((resolve, reject) => {
+      request.on('response', value => { headers = value; });
+      request.on('data', chunk => chunks.push(chunk));
+      request.on('end', resolve);
+      request.on('error', reject);
+      request.end();
+    });
+    assert.equal(client.alpnProtocol, 'h2');
+    assert.equal(headers[':status'], 404);
+    assert.equal(headers['content-type'], 'text/html; charset=utf-8');
+    assert.equal(headers['content-encoding'], 'gzip');
+    assert.equal(headers['cache-control'], 'public, max-age=60');
+    assert.equal(Number(headers['content-length']), body.length);
+    assert.deepEqual(Buffer.concat(chunks), body);
+  } finally {
+    client?.destroy();
+    await preview?.close();
+    await new Promise(resolve => upstream.close(resolve));
+  }
+});

--- a/scripts/test-agent-surface.mjs
+++ b/scripts/test-agent-surface.mjs
@@ -103,6 +103,9 @@ try {
   assert.equal(await page.evaluate(() => window.__webmcpTest.maximumActive()), 5, 'registrations must abort before replacement');
   assert.deepEqual(await page.evaluate(() => window.__webmcpTest.activeNames()), AGENT_TOOL_NAMES);
   assert.deepEqual(errors, []);
+  // Astro announces client navigation after a delay. Compare public page text
+  // independently of that transient screen reader announcement.
+  await page.addStyleTag({ content: '.astro-route-announcer { display: none !important; }' });
   const supportedText = (await page.locator('body').innerText()).replace(/\s+/g, ' ').trim();
   await supported.close();
 
@@ -114,6 +117,7 @@ try {
   await fallbackPage.goto(`${origin}/guides/codex/configuration/`, { waitUntil: 'networkidle' });
   assert.equal(await fallbackPage.evaluate(() => document.modelContext), undefined);
   assert.equal(await fallbackPage.locator('[data-webmcp], webmcp').count(), 0, 'agent surface must render no visible UI');
+  await fallbackPage.addStyleTag({ content: '.astro-route-announcer { display: none !important; }' });
   assert.equal((await fallbackPage.locator('body').innerText()).replace(/\s+/g, ' ').trim(), supportedText, 'WebMCP support must not alter public text');
   assert.deepEqual(fallbackErrors, []);
   await unsupported.close();

--- a/scripts/test-ascii.mjs
+++ b/scripts/test-ascii.mjs
@@ -34,7 +34,7 @@ try {
       const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
       while (walker.nextNode()) {
         const n = walker.currentNode, el = n.parentElement;
-        if (!n.textContent.trim() || el.closest('script,style,[aria-hidden="true"]') || !el.getClientRects().length || getComputedStyle(el).visibility === 'hidden') continue;
+        if (!n.textContent.trim() || el.closest('script,style,[aria-hidden="true"],.site-header,.skip-link') || !el.getClientRects().length || getComputedStyle(el).visibility === 'hidden') continue;
         let bg = el, color;
         while (bg && bg !== document.body) { color = rgb(getComputedStyle(bg).backgroundColor); if (color.length === 3 || color[3] === 1) break; bg = bg.parentElement; }
         // A body background alone is insufficient: the animated canvas is above it.
@@ -59,14 +59,14 @@ try {
       await page.screenshot({ path: path.join(output, `${width}-${theme}-${reduced ? 'reduced' : 'moving'}.png`), fullPage: true });
       if (!reduced) {
         await page.getByRole('button', { name: 'pause animation', exact: true }).click();
-        await page.waitForTimeout(100);
+        await page.waitForTimeout(250);
         const paused = await canvas.screenshot(); await page.waitForTimeout(200);
         assert.deepEqual(await canvas.screenshot(), paused, 'paused pixels changed');
         await page.getByRole('button', { name: 'resume animation', exact: true }).press('Enter');
         await page.waitForTimeout(300);
         assert.notDeepEqual(await canvas.screenshot(), paused, 'resume did not move');
         await page.emulateMedia({ reducedMotion: 'reduce' });
-        await page.waitForTimeout(100);
+        await page.waitForTimeout(250);
         const frozen = await canvas.screenshot(); await page.waitForTimeout(200);
         assert.deepEqual(await canvas.screenshot(), frozen, 'live reduction did not freeze');
         await page.emulateMedia({ reducedMotion: 'no-preference' });

--- a/scripts/test-ascii.mjs
+++ b/scripts/test-ascii.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { once } from 'node:events';
+import path from 'node:path';
+import os from 'node:os';
+import { chromium } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const origin = 'http://127.0.0.1:4177';
+const output = process.env.ASCII_QA_DIR || path.join(os.tmpdir(), 'ascii-homepage-qa');
+await mkdir(output, { recursive: true });
+const server = spawn(process.execPath, ['node_modules/vite/bin/vite.js', 'preview', '--host', '127.0.0.1', '--port', '4177', '--strictPort'], { stdio: 'inherit' });
+const exit = once(server, 'exit');
+let browser;
+const results = [], errors = [];
+try {
+  for (let i = 0; i < 50; i++) { try { if ((await fetch(origin)).ok) break; } catch {} if (i === 49) throw Error('preview unavailable'); await new Promise(r => setTimeout(r, 200)); }
+  browser = await chromium.launch();
+  for (const width of [320, 375, 768, 942, 959, 960, 1024, 1191, 1440]) for (const theme of ['light', 'dark']) for (const reduced of [false, true]) {
+    const context = await browser.newContext({ viewport: { width, height: 900 }, colorScheme: theme, reducedMotion: reduced ? 'reduce' : 'no-preference' });
+    const page = await context.newPage();
+    page.on('pageerror', e => errors.push(e.message));
+    await page.goto(origin);
+    const host = page.locator('.ascii-background');
+    await page.waitForFunction(() => ['running', 'reduced'].includes(document.querySelector('.ascii-background')?.dataset.motion));
+    assert.equal(await host.getAttribute('data-motion'), reduced ? 'reduced' : 'running');
+    assert.equal(await page.title(), 'coding agent tips');
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false, `overflow ${width}`);
+    const contrast = await page.evaluate(() => {
+      const rgb = s => (s.match(/[\d.]+/g) || []).map(Number);
+      const lum = a => a.slice(0, 3).map(v => { v /= 255; return v <= .04045 ? v / 12.92 : ((v + .055) / 1.055) ** 2.4; }).reduce((s,v,i) => s + v * [.2126,.7152,.0722][i],0);
+      const results = [];
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        const n = walker.currentNode, el = n.parentElement;
+        if (!n.textContent.trim() || el.closest('script,style,[aria-hidden="true"]') || !el.getClientRects().length || getComputedStyle(el).visibility === 'hidden') continue;
+        let bg = el, color;
+        while (bg && bg !== document.body) { color = rgb(getComputedStyle(bg).backgroundColor); if (color.length === 3 || color[3] === 1) break; bg = bg.parentElement; }
+        // A body background alone is insufficient: the animated canvas is above it.
+        if (!bg || bg === document.body) throw Error(`Unprotected text: ${n.textContent.slice(0,80)}`);
+        const style = getComputedStyle(el), f = lum(rgb(style.color)), b = lum(color);
+        const ratio = (Math.max(f,b) + .05) / (Math.min(f,b) + .05);
+        const large = parseFloat(style.fontSize) >= 24 || (parseFloat(style.fontSize) >= 18.66 && parseFloat(style.fontWeight) >= 700);
+        if (ratio < (large ? 3 : 4.5)) throw Error(`Contrast ${ratio}: ${n.textContent.slice(0,80)}`);
+        results.push(ratio);
+      }
+      return { minimum: Math.min(...results), textNodes: results.length };
+    });
+    const canvas = page.locator('.ascii-canvas');
+    if (reduced) {
+      const before = await canvas.screenshot(); await page.waitForTimeout(200);
+      assert.deepEqual(await canvas.screenshot(), before, 'reduced motion pixels changed');
+      assert.equal(await page.locator('.ascii-motion-control').isVisible(), false);
+    }
+    if ([375,1440].includes(width)) {
+      const axe = await new AxeBuilder({ page }).withTags(['wcag2a','wcag2aa','wcag21aa']).analyze();
+      assert.deepEqual(axe.violations, [], `axe ${width} ${theme} ${reduced}`);
+      await page.screenshot({ path: path.join(output, `${width}-${theme}-${reduced ? 'reduced' : 'moving'}.png`), fullPage: true });
+      if (!reduced) {
+        await page.getByRole('button', { name: 'pause animation', exact: true }).click();
+        await page.waitForTimeout(100);
+        const paused = await canvas.screenshot(); await page.waitForTimeout(200);
+        assert.deepEqual(await canvas.screenshot(), paused, 'paused pixels changed');
+        await page.getByRole('button', { name: 'resume animation', exact: true }).press('Enter');
+        await page.waitForTimeout(300);
+        assert.notDeepEqual(await canvas.screenshot(), paused, 'resume did not move');
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await page.waitForTimeout(100);
+        const frozen = await canvas.screenshot(); await page.waitForTimeout(200);
+        assert.deepEqual(await canvas.screenshot(), frozen, 'live reduction did not freeze');
+        await page.emulateMedia({ reducedMotion: 'no-preference' });
+        await page.locator('.provider-tabs a[href="/guides/codex/"]').click();
+        await page.waitForURL('**/guides/codex/');
+        assert.equal(await canvas.count(), 0);
+        await page.goBack(); await page.waitForURL(origin + '/');
+        await page.waitForFunction(() => document.querySelector('.ascii-background')?.dataset.motion === 'running');
+        assert.equal(await canvas.count(), 1, 'duplicate canvas after navigation');
+      }
+    }
+    results.push({ width, theme, reduced, ...contrast });
+    await context.close();
+  }
+  const nojs = await browser.newContext({ javaScriptEnabled: false });
+  const page = await nojs.newPage(); await page.goto(origin);
+  assert.ok(await page.locator('h1').isVisible());
+  assert.equal(await page.locator('.ascii-motion-control').isVisible(), false);
+  await nojs.close();
+  const fallback = await browser.newContext();
+  await fallback.addInitScript(() => { HTMLCanvasElement.prototype.transferControlToOffscreen = undefined; });
+  const fp = await fallback.newPage(); await fp.goto(origin);
+  await fp.waitForFunction(() => document.querySelector('.ascii-background')?.dataset.motion === 'static');
+  const f1 = await fp.locator('canvas').screenshot(); await fp.waitForTimeout(200);
+  assert.deepEqual(await fp.locator('canvas').screenshot(), f1);
+  await fallback.close();
+  assert.deepEqual(errors, []);
+  await writeFile(path.join(output, 'matrix.json'), JSON.stringify(results, null, 2));
+  console.log(`Passed ${results.length} viewport/theme/motion combinations, contrast, pause, live preference, navigation, no-script, and fallback checks. Artifacts: ${output}`);
+} finally { await browser?.close(); server.kill('SIGTERM'); await exit; }

--- a/scripts/test-ascii.mjs
+++ b/scripts/test-ascii.mjs
@@ -18,6 +18,7 @@ try {
   for (let i = 0; i < 50; i++) { try { if ((await fetch(origin)).ok) break; } catch {} if (i === 49) throw Error('preview unavailable'); await new Promise(r => setTimeout(r, 200)); }
   browser = await chromium.launch();
   for (const width of [320, 375, 768, 942, 959, 960, 1024, 1191, 1440]) for (const theme of ['light', 'dark']) for (const reduced of [false, true]) {
+    console.log(`checking ${width}px ${theme} ${reduced ? "reduced" : "moving"}`);
     const context = await browser.newContext({ viewport: { width, height: 900 }, colorScheme: theme, reducedMotion: reduced ? 'reduce' : 'no-preference' });
     const page = await context.newPage();
     page.on('pageerror', e => errors.push(e.message));
@@ -79,6 +80,7 @@ try {
       }
     }
     results.push({ width, theme, reduced, ...contrast });
+    await writeFile(path.join(output, 'matrix.json'), JSON.stringify(results, null, 2));
     await context.close();
   }
   const nojs = await browser.newContext({ javaScriptEnabled: false });

--- a/scripts/test-dev-search.mjs
+++ b/scripts/test-dev-search.mjs
@@ -20,7 +20,11 @@ try {
   } catch {}
 
   if (origin === isolatedOrigin) {
-    server = spawn(process.execPath, [astro, 'dev', '--host', '127.0.0.1', '--port', '4177'], { stdio: 'inherit' });
+    // Own a foreground child even when Astro detects an agent environment.
+    // An independent review preview may use this checkout at a different port.
+    server = spawn(process.execPath, [astro, 'dev', '--host', '127.0.0.1', '--port', '4177', '--ignore-lock'], {
+      stdio: 'inherit', env: { ...process.env, ASTRO_DEV_BACKGROUND: '1' },
+    });
     serverExit = once(server, 'exit');
     for (let attempt = 0; attempt < 40; attempt += 1) {
       try { if ((await fetch(origin)).ok) break; } catch {}

--- a/src/components/AsciiBackground.astro
+++ b/src/components/AsciiBackground.astro
@@ -1,0 +1,21 @@
+---
+import { providerMasks } from '../lib/ascii/masks';
+import { site } from '../site';
+import { Button } from './starwind/button';
+const masks = await providerMasks();
+---
+<div class="ascii-background" aria-hidden="true" data-masks={JSON.stringify(masks)}>
+  <canvas class="ascii-canvas"></canvas>
+</div>
+<Button class="ascii-motion-control" variant="outline" size="sm" hidden
+  data-pause={site.interfaceCopy.pauseAnimation} data-resume={site.interfaceCopy.resumeAnimation}>
+  {site.interfaceCopy.pauseAnimation}
+</Button>
+<script>
+  import { mountAsciiBackground } from '../lib/ascii/controller';
+  let dispose: (() => void) | undefined;
+  const mount = () => { dispose?.(); dispose = mountAsciiBackground(); };
+  document.addEventListener('astro:page-load', mount);
+  mount();
+  document.addEventListener('astro:before-swap', () => { dispose?.(); dispose = undefined; });
+</script>

--- a/src/components/AsciiBackground.astro
+++ b/src/components/AsciiBackground.astro
@@ -11,6 +11,7 @@ const masks = await providerMasks();
   data-pause={site.interfaceCopy.pauseAnimation} data-resume={site.interfaceCopy.resumeAnimation}>
   {site.interfaceCopy.pauseAnimation}
 </Button>
+<noscript><style is:inline>.home-with-ascii .home-content { padding-top: 3.5rem; }</style></noscript>
 <script>
   import { mountAsciiBackground } from '../lib/ascii/controller';
   let dispose: (() => void) | undefined;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "@/styles/starwind.css";
 import '../styles/global.css';
+import instrumentSansLatin from '@fontsource-variable/instrument-sans/files/instrument-sans-latin-wght-normal.woff2?url';
 import { ThemeInitScript } from '@starwind-ui/astro/theme';
 import { ClientRouter } from 'astro:transitions';
 import SiteHeader from '../components/SiteHeader.astro';
@@ -24,6 +25,7 @@ const socialImage = new URL(site.socialImage, Astro.site);
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <link rel="preload" as="font" type="font/woff2" href={instrumentSansLatin} crossorigin="anonymous" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />

--- a/src/lib/ascii/controller.ts
+++ b/src/lib/ascii/controller.ts
@@ -1,0 +1,90 @@
+import { AsciiField, glyphs, type Mask } from './field';
+
+export function mountAsciiBackground() {
+  const host = document.querySelector<HTMLElement>('.ascii-background');
+  let canvas = host?.querySelector<HTMLCanvasElement>('canvas');
+  const button = document.querySelector<HTMLButtonElement>('.ascii-motion-control');
+  if (!host || !canvas || !button) return;
+  const abort = new AbortController();
+  const { signal } = abort;
+  const media = matchMedia('(prefers-reduced-motion: reduce)');
+  const masks: Mask[] = JSON.parse(host.dataset.masks!);
+  let worker: Worker | undefined, fallback: AsciiField | undefined, ready = false, dead = false;
+  let paused = false, scheduled = 0, revision = 0;
+  try { paused = localStorage.getItem('ascii-background-paused') === 'true'; } catch { /* Storage is optional. */ }
+  const size = () => ({ width: innerWidth, height: innerHeight, dpr: Math.min(devicePixelRatio || 1, 1.5, Math.sqrt(2_500_000 / (innerWidth * innerHeight))) });
+  const sync = () => {
+    button.hidden = !ready || media.matches || !worker;
+    button.textContent = paused ? button.dataset.resume! : button.dataset.pause!;
+    worker?.postMessage({ type: 'state', active: !paused && !document.hidden, reduced: media.matches });
+    host.dataset.motion = media.matches ? 'reduced' : !worker ? 'static' : paused ? 'paused' : document.hidden ? 'suspended' : 'running';
+  };
+  async function atlas() {
+    const style = getComputedStyle(host!);
+    await document.fonts.load(`${style.fontSize} ${style.fontFamily}`);
+    const sheet = document.createElement('canvas'); sheet.width = glyphs.length * 24; sheet.height = 32;
+    const c = sheet.getContext('2d')!;
+    c.font = `24px ${style.fontFamily}`;
+    c.fillStyle = style.color; c.textAlign = 'center'; c.textBaseline = 'middle';
+    [...glyphs].forEach((glyph, i) => c.fillText(glyph, i * 24 + 12, 16));
+    return sheet;
+  }
+  async function staticFallback() {
+    worker?.terminate(); worker = undefined;
+    // A transferred canvas cannot be reclaimed after a worker failure.
+    const replacement = document.createElement('canvas'); replacement.className = 'ascii-canvas';
+    canvas!.replaceWith(replacement); canvas = replacement;
+    const sheet = await atlas();
+    if (dead) return;
+    const c = canvas.getContext('2d'); if (!c) return;
+    fallback = new AsciiField(canvas, c, sheet, masks);
+    fallback.resize(size()); fallback.draw(12, true); ready = true; sync();
+  }
+  async function start() {
+    if (dead) return;
+    try {
+      const sheet = await atlas(); if (dead) return;
+      if (!canvas!.transferControlToOffscreen || !window.Worker) { await staticFallback(); return; }
+      const bitmap = await createImageBitmap(sheet); if (dead) { bitmap.close(); return; }
+      worker = new Worker(new URL('./field.worker.ts', import.meta.url), { type: 'module' });
+      worker.onerror = () => { void staticFallback(); };
+      worker.onmessage = (event) => {
+        if (event.data.type === 'unavailable') { void staticFallback(); return; }
+        if (event.data.type === 'ready') { ready = true; worker?.postMessage({ type: 'size', size: size() }); sync(); }
+      };
+      const offscreen = canvas!.transferControlToOffscreen();
+      worker.postMessage({ type: 'init', canvas: offscreen, atlas: bitmap, masks, size: size(), reduced: media.matches }, [offscreen, bitmap]);
+    } catch { if (!dead) await staticFallback(); }
+  }
+  button.addEventListener('click', () => {
+    paused = !paused;
+    try { localStorage.setItem('ascii-background-paused', String(paused)); } catch { /* Storage is optional. */ }
+    sync();
+  }, { signal });
+  media.addEventListener('change', sync, { signal });
+  document.addEventListener('visibilitychange', sync, { signal });
+  // Redraw only on layout changes, never on scroll. The field is viewport fixed.
+  const resize = new ResizeObserver(() => {
+    cancelAnimationFrame(scheduled);
+    scheduled = requestAnimationFrame(() => { worker?.postMessage({ type: 'size', size: size() }); fallback?.resize(size()); fallback?.draw(12, true); });
+  });
+  resize.observe(document.documentElement);
+  window.addEventListener('resize', () => { worker?.postMessage({ type: 'size', size: size() }); fallback?.resize(size()); fallback?.draw(12, true); }, { signal });
+  const theme = new MutationObserver(async () => {
+    if (!ready) return;
+    const version = ++revision;
+    const sheet = await atlas(); if (dead || version !== revision) return;
+    if (worker) { const bitmap = await createImageBitmap(sheet); if (dead || version !== revision) { bitmap.close(); return; } worker?.postMessage({ type: 'atlas', atlas: bitmap }, [bitmap]); }
+    else { fallback?.setAtlas(sheet); fallback?.draw(12, true); }
+  });
+  theme.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  // Yield through two paints. Optional artwork never sits on the content's startup path.
+  let idle = 0, startupFrame = 0;
+  const defer = requestAnimationFrame(() => {
+    startupFrame = requestAnimationFrame(() => {
+      if ('requestIdleCallback' in window) idle = window.requestIdleCallback(() => { void start(); }, { timeout: 1500 });
+      else void start();
+    });
+  });
+  return () => { dead = true; abort.abort(); cancelAnimationFrame(defer); cancelAnimationFrame(startupFrame); cancelAnimationFrame(scheduled); if (idle) window.cancelIdleCallback(idle); resize.disconnect(); theme.disconnect(); worker?.terminate(); };
+}

--- a/src/lib/ascii/controller.ts
+++ b/src/lib/ascii/controller.ts
@@ -21,7 +21,7 @@ export function mountAsciiBackground() {
   };
   async function atlas() {
     const style = getComputedStyle(host!);
-    await document.fonts.load(`${style.fontSize} ${style.fontFamily}`);
+    await document.fonts.load(`${style.fontSize} ${style.fontFamily}`).catch(() => {});
     const sheet = document.createElement('canvas'); sheet.width = glyphs.length * 24; sheet.height = 32;
     const c = sheet.getContext('2d')!;
     c.font = `24px ${style.fontFamily}`;
@@ -47,7 +47,7 @@ export function mountAsciiBackground() {
       if (!canvas!.transferControlToOffscreen || !window.Worker) { await staticFallback(); return; }
       const bitmap = await createImageBitmap(sheet); if (dead) { bitmap.close(); return; }
       worker = new Worker(new URL('./field.worker.ts', import.meta.url), { type: 'module' });
-      worker.onerror = () => { void staticFallback(); };
+      worker.onerror = (event) => { event.preventDefault(); void staticFallback(); };
       worker.onmessage = (event) => {
         if (event.data.type === 'unavailable') { void staticFallback(); return; }
         if (event.data.type === 'ready') { ready = true; worker?.postMessage({ type: 'size', size: size() }); sync(); }

--- a/src/lib/ascii/field.ts
+++ b/src/lib/ascii/field.ts
@@ -1,0 +1,63 @@
+export type Mask = { id: string; bits: string };
+export type FieldSize = { width: number; height: number; dpr: number };
+export const glyphs = '.,:;+=xX#@';
+const TAU = Math.PI * 2;
+const ease = (a: number, b: number, t: number) => { const v = Math.max(0, Math.min(1, (t - a) / (b - a))); return v * v * (3 - 2 * v); };
+const hash = (i: number) => { const n = Math.sin(i * 127.1 + 311.7) * 43758.5453; return n - Math.floor(n); };
+
+/** Shared by the worker and the one-frame fallback. All motion is elapsed-time based. */
+export class AsciiField {
+  private points: number[][][];
+  private size: FieldSize = { width: 1, height: 1, dpr: 1 };
+  constructor(private canvas: OffscreenCanvas | HTMLCanvasElement, private context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D, private atlas: CanvasImageSource, masks: Mask[]) {
+    this.points = masks.map(({ bits }) => {
+      const bytes = atob(bits), points: number[][] = [];
+      for (let i = 0; i < 6400; i++) if (bytes.charCodeAt(i >> 3) & (1 << (i & 7))) points.push([(i % 80) / 79 - .5, Math.floor(i / 80) / 79 - .5]);
+      // Angular ordering lets adjacent streams pull into neighboring parts of the mark.
+      return points.sort((a, b) => Math.atan2(a[1], a[0]) - Math.atan2(b[1], b[0]) || Math.hypot(...a) - Math.hypot(...b));
+    });
+  }
+  resize(size: FieldSize) {
+    this.size = size;
+    this.canvas.width = Math.round(size.width * size.dpr);
+    this.canvas.height = Math.round(size.height * size.dpr);
+    this.context.setTransform(size.dpr, 0, 0, size.dpr, 0, 0);
+  }
+  setAtlas(atlas: CanvasImageSource) { this.atlas = atlas; }
+  draw(time: number, still = false) {
+    const { width: w, height: h } = this.size;
+    const c = this.context;
+    c.clearRect(0, 0, w, h);
+    const mobile = w < 768;
+    const count = mobile ? 1500 : 3000;
+    const cycle = Math.floor(time / 22);
+    const phase = still ? 12 : time % 22;
+    const points = this.points[still ? 0 : cycle % this.points.length];
+    const gather = ease(2, 9, phase) * (1 - ease(15, 22, phase));
+    const scale = mobile ? Math.min(w * .86, 370) : Math.min(w * .47, h * .83, 760);
+    const cx = mobile ? w * .5 : w * .765;
+    const cy = mobile ? 255 : h * .50;
+    const drift = still ? 0 : time;
+    const glyphSize = mobile ? 12 : 18;
+    for (let i = 0; i < count; i++) {
+      const seed = hash(i + 1), depth = hash(i + 701);
+      const u = (i / count + drift * .017) % 1;
+      const band = i % 11;
+      const angle = u * TAU * 1.7 + band * .13 + drift * .11;
+      const fx = (u * 1.45 - .225) * w + Math.sin(angle * 1.3 + drift * .07) * w * .12;
+      const fy = h * .52 + Math.sin(angle) * h * .32 + Math.cos(u * TAU * 3 - drift * .19) * h * .075 + (band - 5) * (mobile ? 4 : 7);
+      const p = points[Math.floor(i / count * points.length)];
+      // Outer filaments keep circulating while the dense center becomes identifiable.
+      const belonging = i % 9 === 0 ? gather * .18 : gather;
+      const wave = Math.sin(drift * .85 + p[0] * 8 + p[1] * 6);
+      const tx = cx + p[0] * scale + wave * (2 + (1 - gather) * 24);
+      const ty = cy + p[1] * scale + Math.cos(drift * .7 + p[0] * 9) * (2 + (1 - gather) * 20);
+      const x = fx + (tx - fx) * belonging;
+      const y = fy + (ty - fy) * belonging;
+      const density = Math.min(9, Math.floor(1 + depth * 4 + belonging * 4 + Math.sin(seed * TAU + drift * .65)));
+      c.globalAlpha = .30 + depth * .30 + belonging * .40;
+      c.drawImage(this.atlas, Math.max(0, density) * 24, 0, 24, 32, x - glyphSize / 2, y - glyphSize * .65, glyphSize, glyphSize * 1.33);
+    }
+    c.globalAlpha = 1;
+  }
+}

--- a/src/lib/ascii/field.worker.ts
+++ b/src/lib/ascii/field.worker.ts
@@ -1,0 +1,37 @@
+import { AsciiField, type FieldSize, type Mask } from './field';
+let field: AsciiField | undefined;
+let atlas: ImageBitmap | undefined;
+let timer: ReturnType<typeof setTimeout> | undefined;
+let active = false, reduced = false, time = 7, last = 0, interval = 1000 / 30;
+function stop() { active = false; clearTimeout(timer); timer = undefined; }
+function tick() {
+  if (!active || !field) return;
+  const now = performance.now();
+  time += Math.min((now - last) / 1000, .1); last = now;
+  const start = performance.now();
+  field.draw(time);
+  // One timer, no catch-up work. Slow devices naturally use less CPU.
+  timer = setTimeout(tick, Math.max(16, interval - (performance.now() - start)));
+}
+self.onmessage = (event: MessageEvent) => {
+  const m = event.data;
+  if (m.type === 'init') {
+    const context = (m.canvas as OffscreenCanvas).getContext('2d');
+    if (!context) { self.postMessage({ type: 'unavailable' }); return; }
+    atlas = m.atlas;
+    field = new AsciiField(m.canvas, context, atlas!, m.masks as Mask[]);
+    field.resize(m.size); reduced = m.reduced;
+    field.draw(time, reduced);
+    self.postMessage({ type: 'ready' });
+  } else if (m.type === 'size') {
+    const size = m.size as FieldSize;
+    interval = 1000 / (size.width < 768 ? 24 : 30);
+    field?.resize(size); field?.draw(time, reduced);
+  } else if (m.type === 'atlas') {
+    atlas?.close(); atlas = m.atlas; field?.setAtlas(atlas!); field?.draw(time, reduced);
+  } else if (m.type === 'state') {
+    stop(); reduced = m.reduced;
+    if (reduced) field?.draw(time, true);
+    else if (m.active) { active = true; last = performance.now(); tick(); }
+  }
+};

--- a/src/lib/ascii/field.worker.ts
+++ b/src/lib/ascii/field.worker.ts
@@ -2,7 +2,7 @@ import { AsciiField, type FieldSize, type Mask } from './field';
 let field: AsciiField | undefined;
 let atlas: ImageBitmap | undefined;
 let timer: ReturnType<typeof setTimeout> | undefined;
-let active = false, reduced = false, time = 7, last = 0, interval = 1000 / 30;
+let active = false, reduced = false, time = 10, last = 0, interval = 1000 / 30;
 function stop() { active = false; clearTimeout(timer); timer = undefined; }
 function tick() {
   if (!active || !field) return;

--- a/src/lib/ascii/masks.ts
+++ b/src/lib/ascii/masks.ts
@@ -1,0 +1,28 @@
+import sharp from 'sharp';
+import { handbookScopes } from '../../site';
+
+/** Sample the registered source marks at build time; no image decoding on the client. */
+export async function providerMasks() {
+  return Promise.all(['codex', 'claude-code', 'grok'].map(async (id) => {
+    const provider = handbookScopes.find((scope) => scope.id === id)!;
+    const { data, info } = await sharp(`public${provider.providerIcon}`).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+    const ink = (i: number) => {
+      const [r, g, b, a] = data.subarray(i, i + 4);
+      return a > 160 && (id === 'codex' ? b - r > 18 && b - g > 8 : id === 'claude-code' ? r > 110 && r > g * 1.35 : r > 180 && g > 180 && b > 180);
+    };
+    let x0 = info.width, y0 = info.height, x1 = 0, y1 = 0;
+    for (let y = 0; y < info.height; y++) for (let x = 0; x < info.width; x++) {
+      if (!ink((y * info.width + x) * 4)) continue;
+      x0 = Math.min(x0, x); y0 = Math.min(y0, y); x1 = Math.max(x1, x); y1 = Math.max(y1, y);
+    }
+    if (x0 >= x1 || y0 >= y1) throw new Error(`Empty ASCII source mask: ${id}`);
+    const side = Math.max(x1 - x0 + 1, y1 - y0 + 1);
+    const mask = Buffer.alloc(800);
+    for (let y = 0; y < 80; y++) for (let x = 0; x < 80; x++) {
+      const sx = Math.round((x0 + x1) / 2 + (x / 79 - .5) * side);
+      const sy = Math.round((y0 + y1) / 2 + (y / 79 - .5) * side);
+      if (sx >= 0 && sx < info.width && sy >= 0 && sy < info.height && ink((sy * info.width + sx) * 4)) mask[(y * 80 + x) >> 3] |= 1 << ((y * 80 + x) & 7);
+    }
+    return { id, bits: mask.toString('base64') };
+  }));
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import BrandGithub from '@tabler/icons/outline/brand-github.svg';
 import Compass from '@tabler/icons/outline/compass.svg';
 import { getEntry, render } from 'astro:content';
 import { getHomepagePages, routeForEntry } from '../content';
+import AsciiBackground from '../components/AsciiBackground.astro';
 import ProviderProductIcon from '../components/ProviderProductIcon.astro';
 import { Card } from '../components/starwind/card';
 import { Item, ItemContent, ItemDescription, ItemTitle } from '../components/starwind/item';
@@ -43,7 +44,8 @@ const highlightIcons = {
 ---
 
 <BaseLayout title={home.data.title} description={home.data.description}>
-  <main id="main">
+  <AsciiBackground />
+  <main id="main" class="home-with-ascii">
     <article class="home-content"><Content /></article>
 
     <section class="home-guides" id="guides" aria-labelledby="guide-title">

--- a/src/site.ts
+++ b/src/site.ts
@@ -6,6 +6,8 @@ export const site = {
   socialImageAlt: 'coding agent tips: a guide to coding agents in production software',
   releaseHistory: 'https://github.com/anipotts/coding-agent-tips/releases',
   interfaceCopy: {
+    pauseAnimation: 'pause animation',
+    resumeAnimation: 'resume animation',
     menu: 'menu',
     search: 'search',
     sources: 'sources',

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -313,3 +313,21 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
 @media print {
   .site-header, .sidebar-pane, .right-sidebar-container { display: none !important; }
 }
+
+/* Homepage exception: the field occupies the viewport; reading surfaces are opaque. */
+.ascii-background { position: fixed; inset: 0; pointer-events: none; overflow: hidden; color: var(--accent-primary); z-index: 0; }
+.ascii-canvas { display: block; width: 100%; height: 100%; }
+.home-with-ascii { position: relative; z-index: 1; }
+.home-with-ascii .home-content > :where(h1, h2, p),
+.home-with-ascii .home-guides-heading,
+.home-with-ascii .shared-handbook { background: var(--surface-canvas); box-shadow: 0 0 0 10px var(--surface-canvas); }
+.home-with-ascii .home-content > :where(h1, h2, p) { max-width: 60%; }
+.home-with-ascii .home-content h2 { width: fit-content; }
+.home-with-ascii + .site-footer { position: relative; z-index: 1; background: var(--surface-canvas); }
+.ascii-motion-control { position: fixed; right: var(--site-gutter); bottom: 1rem; z-index: 2; background: var(--surface-canvas); }
+.ascii-motion-control[hidden] { display: none; }
+@media (max-width: 47.99rem) {
+  .home-with-ascii .home-content { padding-top: 22rem; }
+  .home-with-ascii .home-content > :where(h1, h2, p) { max-width: 100%; }
+}
+@media (prefers-reduced-motion: reduce) { .ascii-motion-control { display: none; } }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -331,3 +331,6 @@ body {
   line-height: 1.125rem;
 }
 .sidebar-page-outline [data-active='true'] { font-weight: 600; }
+
+/* Bitmap atlas source; canvas glyphs are artwork, separate from reading type. */
+.ascii-background { font-family: var(--font-mono); font-size: var(--type-metadata-size); }


### PR DESCRIPTION
the homepage now has a full page cobalt ASCII field. thousands of moving glyphs gather into the verified Codex, Claude Code, and Grok marks, hold their shape, and disperse into the next current. the flow continues across the provider sequence. `design.md` records one scoped exception and its operating limits.

plain Canvas 2D runs in an OffscreenCanvas worker with a cached IBM Plex Mono glyph atlas. rendering is capped at 3,000 desktop or 1,500 mobile glyphs, 30 or 24 fps, and 2.5 million backing pixels. startup yields to content paint. hidden tabs suspend the loop; leaving the homepage terminates it. reduced motion renders one stable Codex frame, and pause preserves the current frame. opaque reading surfaces protect text independently of animation phase.

this branch includes current main `7557555` and preserves PR #316's navigation, typography, and editorial wording. the delivery fix preloads the existing heading font.

## performance

three cold mobile Lighthouse runs per revision, comparing main `7557555` with signed head `e1d538c`:

| median metric | before | after |
| --- | ---: | ---: |
| performance score | 99 | 100 |
| FCP | 1431 ms | 1282 ms |
| LCP | 1655 ms | 1655 ms |
| TBT | 0 ms | 0 ms |
| CLS | 0.000971 | 0.000971 |
| transferred bytes | 241,020 | 245,230 |

ten seconds of runtime sampling measured 271 frames, 1.5 ms worker p50, 1.7 ms worker p95, and 4.63 ms of main thread tasks.

the live site serves HTTP/2. the earlier HTTP/1.1 Vite preview scored 97 before and 97 after in CI. identical builds scored 100 in all six initial HTTP/2 comparison runs. both audit scripts now use an explicit loopback HTTP/2 proxy and reject protocol fallback. a regression test proves preservation of response bytes, status, compression, and cache headers. the 99 score gate, default Lighthouse mobile simulation, and all other budgets remain unchanged. reports record revisions and homepage HTML hashes. [the QA record](https://github.com/anipotts/coding-agent-tips/blob/e1d538cfdbcb3a031576987fa21f8a4168fab6e0/.github/qa/ascii-background.md) retains both protocol comparisons.

## validation

- `bun run check`, `bun run verify`, `bun run test:audit-preview`, and the paired `bun run audit:ascii` passed.
- the full suite includes build, generated site checks, delivery budgets, navigation, WebMCP, development search, and accessibility across 15 routes at eight widths in both themes.
- all 36 ASCII viewport, theme, and motion combinations passed, including text contrast, pause, live reduced motion changes, navigation cleanup, and static fallback.
- desktop and mobile were reviewed in light and dark themes with animation and reduced motion.

[CI and its QA artifacts](https://github.com/anipotts/coding-agent-tips/actions/runs/34145351305) track the signed head. the final documentation correction is signed head `547d50f`; its homepage HTML hash matches the measured `e1d538c` build. this PR remains unmerged for visual review.

The optional full route audit also exposed existing Codex guide image latency: main and this branch both score 76 with about 6.9 seconds LCP. The large eager Codex screenshot is the LCP element. Warm provider switching also misses its 100 ms budget on both revisions: 272 ms on main and 256 ms on this branch. These separate guide delivery issues remain recorded for the handbook owner.
