### PR TITLE
refine: unify handbook navigation and compact controls

### DIFF
--- a/design.md
+++ b/design.md
@@ -186,6 +186,19 @@ Use the established roles:
 | navigation | header, rail, and controls |
 | metadata | dates, labels, source counts, and operational identifiers |
 
+Compact interface text uses the copy page control as its baseline: `12px` type,
+`16px` line height, `32px` control height, and `16px` action icons. Outline rows
+use `18px` line height for scanning. Keep document headings, prose, tables, and
+code in their reading roles. Portaled menus and tooltips must retain the same
+interface typography as their triggers, with no inherited prose underlines.
+
+Search expands in the header at the existing control height. On small screens,
+the brand mark remains at the left and the input uses the space before the theme
+and menu buttons. Only results extend below the row; the page remains visible.
+Use a restrained neutral input border and preserve keyboard focus and Escape.
+Page action menus close through Starwind when the document scrolls; scrolling
+inside an overlay does not dismiss it.
+
 Use IBM Plex Mono for code, commands, paths, timestamps, and short operational identifiers. Do not set a sentence or table in Mono because it contains one identifier.
 
 Build vertical rhythm from relationships. Keep a heading close to its first paragraph, a caption close to its evidence, and a new major section visibly separate from the preceding group. Fix measure and composition before shrinking text.
@@ -340,6 +353,10 @@ Search is a core route behavior, not a production-only convenience. Starlight an
 `bun run dev` first builds the static output so a current Pagefind index exists. `src/integrations/starlight-dev-search.mjs` serves that generated index through the Astro development server. Local search must open from the visible header control, accept a query without icon overlap, return current guide results, support keyboard and Escape behavior, and remain free of console errors.
 
 Do not add a separate local search implementation, hard-coded mock results, or a custom command palette. `bun run test:dev-search` is the focused contract; `bun run verify` must continue to include it.
+
+SiteHeader supplies an accessible input name because the installed Pagefind UI
+exposes only a title label. This adapter disconnects after labeling the input and
+on route swaps; it owns no search, menu, focus, or keyboard state.
 
 ### invisible progressive agent-native behavior
 
@@ -515,6 +532,21 @@ At minimum, visually inspect:
 - mobile Sheet, search, page actions, tables, image dialog, disclosures, and footer;
 - keyboard focus, Escape, back and forward, hash links, and scroll restoration;
 - 200 percent resize, text spacing, reduced motion, console output, and overflow.
+
+The consistency coverage inventory is:
+
+| surface | owner and regression coverage |
+| --- | --- |
+| header, provider tabs, theme, mobile Sheet | SiteHeader; navigation and accessibility checks |
+| search trigger, input, results, clear and dismissal | upstream Starlight with shell styles; navigation and development search checks |
+| chapter rail, outline, collapse and progress | StarlightSidebar; navigation and accessibility checks |
+| page actions, portaled menu, clipboard and toast | StarlightPageTitle; navigation checks including scroll dismissal and typography |
+| sources, hover cards, code controls, tables and image dialog | Markdown transformation and PublicationEnhancements; navigation and accessibility checks |
+| homepage groups, footer, document typography and metadata | canonical route rendering; site and accessibility checks |
+
+The accessibility sweep covers all canonical routes at eight widths in both
+themes. Search also receives boundary-width visual checks. This is a defined
+coverage matrix, not a guarantee about every browser or future content change.
 
 ## definition of done
 

--- a/scripts/check-ui-ownership.mjs
+++ b/scripts/check-ui-ownership.mjs
@@ -63,6 +63,7 @@ for (const [file, source] of repositoryText) {
 }
 
 const allowedControllers = new Set([
+  'src/components/SiteHeader.astro', // Pagefind accessible-name adapter only.
   'src/components/PublicationEnhancements.astro',
   'src/components/StarlightPageSidebar.astro',
   'src/components/StarlightPageTitle.astro',

--- a/scripts/test-a11y.mjs
+++ b/scripts/test-a11y.mjs
@@ -32,16 +32,21 @@ try {
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   browser = await chromium.launch({ headless: true });
+  for (const colorScheme of ['light', 'dark']) {
   for (const viewport of viewports) {
-    const context = await browser.newContext({ viewport });
+    const context = await browser.newContext({ viewport, colorScheme });
     const page = await context.newPage();
     for (const route of routes) {
-      await page.goto(`${origin}${route}`, { waitUntil: 'networkidle' });
+      await page.goto(`${origin}${route}`, { waitUntil: 'domcontentloaded' });
+      await page.evaluate(() => document.fonts.ready);
+      // Expressive Code adds keyboard focus after its resize/idle observation.
+      await page.waitForFunction(() => [...document.querySelectorAll('.expressive-code pre')].every((pre) => pre.scrollWidth <= pre.clientWidth || pre.tabIndex === 0));
       if (await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)) failures.push(`${viewport.name} ${route}: horizontal overflow`);
       const typographyFailures = await page.evaluate(({ route, viewportWidth }) => {
         const findings = [];
-        const ink = 'rgb(16, 17, 20)';
-        const slate = 'rgb(80, 87, 96)';
+        const dark = document.documentElement.dataset.theme === 'dark';
+        const ink = dark ? 'rgb(245, 247, 251)' : 'rgb(16, 17, 20)';
+        const slate = dark ? 'rgb(167, 173, 183)' : 'rgb(80, 87, 96)';
         const close = (actual, expected, tolerance = 0.25) => Math.abs(actual - expected) <= tolerance;
         const visible = (element) => element.getClientRects().length > 0 && getComputedStyle(element).visibility !== 'hidden';
         const directText = (element) => [...element.childNodes].some((node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim());
@@ -81,12 +86,13 @@ try {
         checkRole(reading, { size: 18, line: 30, weight: 400, family: 'Instrument Sans', color: ink }, 'reading prose');
         for (const element of reading.filter(visible)) if (element.getBoundingClientRect().width > 816) findings.push(`reading measure exceeds 68ch: ${element.textContent.trim().slice(0, 60)}`);
 
-        checkRole(elements('td, .page-sources li, .run-inventory li, .artifact-list li, .run-page dd'), { size: 16, line: 24, weight: 400, family: 'Instrument Sans', color: ink }, 'dense content');
+        checkRole(elements('td, .run-inventory li, .artifact-list li, .run-page dd'), { size: 16, line: 24, weight: 400, family: 'Instrument Sans', color: ink }, 'dense content');
+        checkRole(elements('.page-sources li'), { size: 12, line: 16, weight: 400, family: 'Instrument Sans', color: ink }, 'source links');
         checkRole(elements('[data-slot="item-description"]'), { size: 16, line: 24, weight: 400, family: 'Instrument Sans', color: slate }, 'guide description');
         const metadata = elements('.section-label, .home-guide-list span, .footer-meta, .sidebar-label, .page-meta, figcaption, .history-year, .run-header > p:first-child, .run-page dt, .run-evidence, .run-inventory span, .source-kinds, th');
         checkRole(metadata, { size: 12, line: 18, weight: 400, family: 'IBM Plex Mono', color: slate }, 'metadata');
-        checkRole(elements('.site-name, .provider-tabs a, .search-trigger, .right-sidebar a, .right-sidebar h2, .site-footer a'), { size: 14, line: 20, family: 'Instrument Sans' }, 'navigation');
-        checkRole(elements('.handbook-sidebar a'), { size: 13, line: 18, family: 'Instrument Sans' }, 'guide navigation');
+        checkRole(elements('.site-name, .provider-tabs a, .search-trigger, .right-sidebar a, .right-sidebar h2, .site-footer a'), { size: 12, line: 16, family: 'Instrument Sans' }, 'navigation');
+        checkRole(elements('.publication-sidebar [data-sidebar="menu-button"], .publication-sidebar [data-sidebar="menu-sub-button"]'), { size: 12, line: 18, family: 'Instrument Sans' }, 'guide navigation');
         return findings;
       }, { route, viewportWidth: viewport.width });
       for (const finding of typographyFailures) failures.push(`${viewport.name} ${route}: ${finding}`);
@@ -140,6 +146,7 @@ try {
     }
     await context.close();
   }
+  }
 } finally {
   await browser?.close();
   if (server.exitCode === null && server.signalCode === null) server.kill('SIGTERM');
@@ -147,4 +154,4 @@ try {
 }
 
 if (failures.length > 0) { console.error(failures.join('\n')); process.exit(1); }
-console.log(`typography, reflow, text spacing, text resize, and axe checks passed across ${routes.length} routes at ${viewports.length} required widths`);
+console.log(`typography, reflow, text spacing, text resize, and axe checks passed across ${routes.length} routes at ${viewports.length} required widths in both themes`);

--- a/scripts/test-dev-search.mjs
+++ b/scripts/test-dev-search.mjs
@@ -39,6 +39,9 @@ try {
   await page.locator('.header-search [data-open-modal]').click();
   const search = page.locator('.header-search site-search dialog');
   await search.waitFor({ state: 'visible' });
+  await page.evaluate(async () => {
+    await Promise.all(document.querySelector('.site-header').getAnimations({ subtree: true }).map((animation) => animation.finished.catch(() => {})));
+  });
   const popoverGeometry = await page.evaluate(() => {
     const trigger = document.querySelector('.header-search [data-open-modal]').getBoundingClientRect();
     const dialog = document.querySelector('.header-search site-search dialog');
@@ -59,7 +62,7 @@ try {
   });
   if (Math.abs(popoverGeometry.top - popoverGeometry.triggerTop) > 2) throw new Error('local search does not expand from the header trigger');
   if (Math.abs(popoverGeometry.right - popoverGeometry.triggerRight) > 2) throw new Error('local search is not aligned to its trigger');
-  if (popoverGeometry.width > 432 || popoverGeometry.height >= popoverGeometry.viewportHeight * .75) throw new Error('local search is not a compact popover');
+  if (popoverGeometry.width > 820 - 100 || popoverGeometry.height > 34) throw new Error('local search must fit its header row at the original control height');
   if (popoverGeometry.backdropColor !== 'rgba(0, 0, 0, 0)' || popoverGeometry.backdropFilter !== 'none') throw new Error('local search still obscures or blurs the page');
   const input = search.locator('input[type="text"], input[type="search"]').first();
   const inputSpacing = await input.evaluate((element) => {

--- a/scripts/test-navigation.mjs
+++ b/scripts/test-navigation.mjs
@@ -93,6 +93,26 @@ try {
     const toggled = await page.locator('html').getAttribute('data-theme');
     expect(toggled !== theme, `${viewport.width}px theme toggle did not change theme`);
     expect(await page.locator('html').evaluate((root) => root.classList.contains('dark') === (root.dataset.theme === 'dark')), `${viewport.width}px Starwind and Starlight theme state diverged`);
+    for (let state = 0; state < 2; state++) {
+      await page.locator('.header-search [data-open-modal]').click();
+      const dialog = page.locator('.header-search dialog');
+      await dialog.waitFor({ state: 'visible' });
+      await page.waitForTimeout(200);
+      const geometry = await dialog.evaluate((element) => {
+        const input = element.querySelector('input');
+        const rect = input.getBoundingClientRect();
+        const logo = document.querySelector('.site-name img').getBoundingClientRect();
+        const theme = document.querySelector('[data-slot="theme-toggle"]').getBoundingClientRect();
+        return { height: rect.height, font: getComputedStyle(input).fontSize, fits: rect.left >= logo.right && rect.right <= theme.left };
+      });
+      expect(geometry.height === 32 && geometry.font === '12px' && geometry.fits, `${viewport.width}px search must fit between brand and utilities in both themes`);
+      await dialog.locator('input').fill('configuration');
+      expect(await dialog.locator('input').getAttribute('aria-label') === 'Search', 'search input needs an explicit accessible name');
+      await dialog.locator('.pagefind-ui__result').first().waitFor();
+      expect(await dialog.locator('.pagefind-ui__drawer').evaluate((element) => element.scrollWidth <= element.clientWidth + 1), `${viewport.width}px search results overflow horizontally`);
+      await page.keyboard.press('Escape');
+      await page.locator('[data-slot="theme-toggle"]').click();
+    }
     await page.locator('[data-slot="theme-toggle"]').click();
   }
 
@@ -139,7 +159,9 @@ try {
     };
   });
   expect(Math.abs(searchBox.y - searchBox.triggerTop) <= 2 && searchBox.x <= searchBox.triggerLeft && searchBox.x + searchBox.width >= searchBox.triggerRight, 'mobile search does not expand through the header trigger');
-  expect(searchBox.width > searchBox.triggerWidth * 4, 'mobile search does not expand into an input surface');
+  expect(searchBox.width > 180 && Math.abs(searchBox.width - searchBox.triggerWidth) < 2, 'mobile search does not occupy its reserved header space');
+  const inputStyle = await search.locator('input').first().evaluate((input) => ({ height: input.getBoundingClientRect().height, font: getComputedStyle(input).fontSize, shadow: getComputedStyle(input).boxShadow }));
+  expect(inputStyle.height === 32 && inputStyle.font === '12px' && inputStyle.shadow === 'none', 'search input diverges from compact control sizing');
   expect(searchBox.x >= 15 && searchBox.width <= searchBox.innerWidth - 30 && searchBox.height < searchBox.innerHeight * .75, 'mobile search is not a compact inset popover');
   expect(searchBox.backdropColor === 'rgba(0, 0, 0, 0)' && searchBox.backdropFilter === 'none', 'mobile search still obscures or blurs the page');
   await search.locator('input[type="text"], input[type="search"]').first().fill('codex');
@@ -160,8 +182,13 @@ try {
   const menu = page.locator('[role="menu"]:visible');
   await menu.waitFor({ state: 'visible' });
   expect((await menu.locator('[role="menuitem"]').allTextContents()).map((text) => text.trim()).join('|') === 'view Markdown|copy page link|edit on GitHub', 'page action menu contents are incorrect');
+  expect(await menu.locator('[role="menuitem"]').evaluateAll((items) => items.every((item) => getComputedStyle(item).fontSize === '12px' && getComputedStyle(item).textDecorationLine === 'none')), 'portaled menu items must retain compact typography without prose underlines');
   await page.keyboard.press('Escape');
   await menu.waitFor({ state: 'hidden' });
+  await page.locator('[aria-label="more page actions"]').click();
+  await page.evaluate(() => window.scrollBy(0, 150));
+  await menu.waitFor({ state: 'hidden' });
+  expect(await page.evaluate(() => window.scrollY >= 150), 'scroll dismissal must not jump back to the page-action trigger');
   await page.locator('[data-copy-page]').click();
   await page.waitForFunction(() => navigator.clipboard.readText().then((text) => text.startsWith('# codex')));
 

--- a/scripts/test-navigation.mjs
+++ b/scripts/test-navigation.mjs
@@ -3,6 +3,7 @@ import { once } from 'node:events';
 import path from 'node:path';
 import process from 'node:process';
 import { chromium } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
 
 const previewPort = 4175;
 const origin = `http://127.0.0.1:${previewPort}`;
@@ -38,7 +39,7 @@ try {
   expect(await page.locator('meta[name="astro-view-transitions-enabled"]').count() === 1, 'ClientRouter marker is missing');
   expect(await page.locator('.provider-tabs a[data-astro-prefetch="hover"]').count() === 4, 'provider tabs are missing selective hover prefetching');
   expect(await page.locator('.publication-sidebar [data-sidebar="menu-button"][data-astro-prefetch="hover"]').count() === 3, 'desktop chapters are missing selective hover prefetching');
-  expect(await page.locator('.mobile-site-menu nav > a[data-astro-prefetch="tap"]').count() === 3, 'mobile chapters are missing selective tap prefetching');
+  expect(await page.locator('.mobile-page-options a[data-astro-prefetch="tap"]').count() >= 13, 'mobile page picker is missing selective tap prefetching');
   expect(await page.locator('.sidebar-page-outline a[data-astro-prefetch]').count() === 0, 'hash links must not be prefetched');
 
   for (const viewport of [
@@ -122,18 +123,35 @@ try {
   await sheetTrigger.click();
   const sheet = page.locator('.mobile-site-menu[role="dialog"]');
   await sheet.waitFor({ state: 'visible' });
-  expect((await sheet.locator('nav a').allTextContents()).map((text) => text.trim()).join('|') === 'overview|configuration|recommendations', 'mobile Sheet chapter order is incorrect');
+  const mobileHeadings = await sheet.locator('.mobile-page-outline a').allTextContents();
+  const desktopHeadings = await page.locator('.sidebar-page-outline').first().locator('a').allTextContents();
+  expect(JSON.stringify(mobileHeadings.map((text) => text.trim())) === JSON.stringify(desktopHeadings.map((text) => text.trim())), 'mobile and desktop heading outlines differ');
+  expect(await sheet.locator('.mobile-page-outline li[style*="1"]').count() > 0, 'mobile outline is missing subsection indentation');
+  const sheetAccessibility = await new AxeBuilder({ page }).include('.mobile-site-menu').analyze();
+  expect(sheetAccessibility.violations.length === 0, `mobile Sheet accessibility: ${sheetAccessibility.violations.map(({ id }) => id).join(', ')}`);
+  expect(await sheet.evaluate((element) => element.scrollWidth <= element.clientWidth), 'mobile Sheet overflows horizontally');
   expect(await page.evaluate(() => document.querySelector('.mobile-site-menu')?.contains(document.activeElement)), 'mobile Sheet does not move focus inside');
   await page.keyboard.press('Escape');
   await sheet.waitFor({ state: 'hidden' });
   expect(await sheetTrigger.evaluate((trigger) => document.activeElement === trigger), 'mobile Sheet does not restore trigger focus');
   await sheetTrigger.click();
-  await sheet.locator('a[href="/guides/codex/configuration/"]').click();
+  await sheet.getByRole('button', { name: 'choose page', exact: true }).click();
+  await page.keyboard.press('Escape');
+  expect(await sheet.isVisible(), 'closing the page picker also closed the Sheet');
+  await sheet.getByRole('button', { name: 'choose page', exact: true }).click();
+  await page.locator('.mobile-page-options a[href="/guides/codex/configuration/"]').click();
   await page.waitForURL('**/guides/codex/configuration/');
   await sheet.waitFor({ state: 'hidden' });
   await page.goBack();
   await page.waitForURL('**/guides/codex/');
   await page.waitForFunction(() => document.querySelector('[data-copy-page]'));
+
+  await sheetTrigger.click();
+  const mobileHeading = sheet.locator('.mobile-page-outline a').first();
+  const mobileHash = await mobileHeading.getAttribute('href');
+  await mobileHeading.click();
+  await sheet.waitFor({ state: 'hidden' });
+  expect(new URL(page.url()).hash === mobileHash, 'mobile heading navigation lost its anchor');
 
   await page.locator('.header-search [data-open-modal]').click();
   const search = page.locator('.header-search site-search dialog');

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -2,9 +2,12 @@
 import Search from '@astrojs/starlight/components/Search.astro';
 import BrandGithub from '@tabler/icons/outline/brand-github.svg';
 import Menu2 from '@tabler/icons/outline/menu-2.svg';
+import ChevronDown from '@tabler/icons/outline/chevron-down.svg';
 import { getHandbookPages, routeForEntry } from '../content';
+import { pageOutline } from '../navigation';
 import { chapterForOrder, navigationScopes, scopeForPath, site } from '../site';
 import { Button } from './starwind/button';
+import { Dropdown, DropdownContent, DropdownGroup, DropdownLabel, DropdownLinkItem, DropdownTrigger } from './starwind/dropdown';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from './starwind/sheet';
 import { ThemeToggle } from './starwind/theme-toggle';
 import { Toaster } from './starwind/toast';
@@ -13,11 +16,15 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './starwind/tooltip';
 const current = Astro.url.pathname;
 const HeaderTag = Astro.props.embedded ? 'div' : 'header';
 const activeScope = scopeForPath(current);
-const scopedPages = await getHandbookPages({ scope: activeScope });
+const pages = await getHandbookPages({ includeArchive: false });
 const activeScopeLabel = navigationScopes.find((scope) => scope.id === activeScope)?.label ?? 'handbook';
-const mobileNavigationLabel = (page: (typeof scopedPages)[number]) => activeScope === 'handbook'
+const mobileNavigationLabel = (page: (typeof pages)[number]) => scopeForPath(routeForEntry(page)) === 'handbook'
   ? page.data.title
   : chapterForOrder(page.data.navigation.order)?.label ?? page.data.title;
+const activePage = pages.find((page) => routeForEntry(page) === current);
+const selectedPageLabel = activePage ? `${activeScopeLabel}: ${mobileNavigationLabel(activePage)}` : 'handbook';
+const route = Astro.props.embedded ? Astro.locals.starlightRoute : undefined;
+const headings = pageOutline(route?.toc?.items, route?.entry.data.completion === 'outline');
 ---
 
 <HeaderTag class="site-header">
@@ -55,30 +62,46 @@ const mobileNavigationLabel = (page: (typeof scopedPages)[number]) => activeScop
           </Button>
         </SheetTrigger>
         <SheetContent class="mobile-site-menu" side="right">
-          <SheetHeader>
-            <SheetTitle>{activeScopeLabel}</SheetTitle>
+          <SheetHeader class="mobile-menu-heading">
+            <SheetTitle>{site.interfaceCopy.guides}</SheetTitle>
           </SheetHeader>
-          <nav aria-label={`${activeScopeLabel} pages`}>
-            {scopedPages.map((page) => {
-              const href = routeForEntry(page);
-              return (
-                <a
-                  href={href}
-                  data-astro-prefetch="tap"
-                  data-sw-drawer-close
-                  aria-current={current === href ? 'page' : undefined}
-                >
-                  {mobileNavigationLabel(page)}
-                </a>
-              );
-            })}
+          <div class="mobile-page-picker">
+            <Dropdown>
+              <DropdownTrigger asChild>
+                <Button class="mobile-page-picker-trigger" variant="outline" size="sm" aria-label={site.interfaceCopy.choosePage}>
+                  <span>{selectedPageLabel}</span><ChevronDown aria-hidden="true" />
+                </Button>
+              </DropdownTrigger>
+              <DropdownContent class="mobile-page-options" align="start">
+                {navigationScopes.map((scope) => (
+                  <DropdownGroup>
+                    <DropdownLabel>{scope.label}</DropdownLabel>
+                    {scope.id === 'handbook' && <DropdownLinkItem href="/" closeOnClick data-sw-drawer-close>handbook home</DropdownLinkItem>}
+                    {pages.filter((page) => scopeForPath(routeForEntry(page)) === scope.id).map((page) => (
+                      <DropdownLinkItem href={routeForEntry(page)} closeOnClick data-sw-drawer-close data-astro-prefetch="tap" aria-current={current === routeForEntry(page) ? 'page' : undefined}>
+                        {mobileNavigationLabel(page)}
+                      </DropdownLinkItem>
+                    ))}
+                  </DropdownGroup>
+                ))}
+              </DropdownContent>
+            </Dropdown>
+          </div>
+          <nav class="mobile-page-navigation" aria-label={site.interfaceCopy.onThisPage}>
+            {headings.length > 0 && <ul class="mobile-page-outline" role="list">
+              {headings.map((heading) => (
+                <li style={`--heading-depth: ${Math.max(0, heading.depth - 2)}`}>
+                  <a href={`#${heading.slug}`} data-heading-id={heading.slug} data-sw-drawer-close>{heading.text}</a>
+                </li>
+              ))}
+            </ul>}
           </nav>
-          <footer>
-            <a href={site.repository} data-sw-drawer-close>
+          <div class="mobile-menu-footer">
+            <Button href={site.repository} variant="ghost" size="sm" data-sw-drawer-close>
               <BrandGithub aria-hidden="true" />
               <span>GitHub</span>
-            </a>
-          </footer>
+            </Button>
+          </div>
         </SheetContent>
       </Sheet>
     </div>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -11,6 +11,7 @@ import { Toaster } from './starwind/toast';
 import { Tooltip, TooltipContent, TooltipTrigger } from './starwind/tooltip';
 
 const current = Astro.url.pathname;
+const HeaderTag = Astro.props.embedded ? 'div' : 'header';
 const activeScope = scopeForPath(current);
 const scopedPages = await getHandbookPages({ scope: activeScope });
 const activeScopeLabel = navigationScopes.find((scope) => scope.id === activeScope)?.label ?? 'handbook';
@@ -19,7 +20,7 @@ const mobileNavigationLabel = (page: (typeof scopedPages)[number]) => activeScop
   : chapterForOrder(page.data.navigation.order)?.label ?? page.data.title;
 ---
 
-<header class="site-header">
+<HeaderTag class="site-header">
   <div class="header-main">
     <a class="site-name" href="/" aria-label={site.interfaceCopy.home}>
       <img src="/favicon.svg" alt="" width="24" height="24" />
@@ -90,5 +91,29 @@ const mobileNavigationLabel = (page: (typeof scopedPages)[number]) => activeScop
       </a>
     ))}
   </nav>
-</header>
+</HeaderTag>
 <Toaster position="bottom-right" duration={3200} />
+
+<script>
+  // Pagefind currently exposes a title-only input label and no input-attribute
+  // configuration. Supply an explicit accessible name without owning search state.
+  let labelObserver: MutationObserver | undefined;
+  const labelSearch = () => {
+    labelObserver?.disconnect();
+    const search = document.querySelector('.header-search');
+    if (!search) return;
+    const labelInput = () => {
+      const input = search.querySelector('input');
+      if (!input) return false;
+      input.setAttribute('aria-label', input.title || 'Search');
+      labelObserver?.disconnect();
+      return true;
+    };
+    if (labelInput()) return;
+    labelObserver = new MutationObserver(labelInput);
+    labelObserver.observe(search, { childList: true, subtree: true });
+  };
+  document.addEventListener('astro:page-load', labelSearch);
+  document.addEventListener('astro:before-swap', () => labelObserver?.disconnect());
+  labelSearch();
+</script>

--- a/src/components/StarlightHeader.astro
+++ b/src/components/StarlightHeader.astro
@@ -2,4 +2,4 @@
 import SiteHeader from './SiteHeader.astro';
 ---
 
-<SiteHeader />
+<SiteHeader embedded />

--- a/src/components/StarlightPageTitle.astro
+++ b/src/components/StarlightPageTitle.astro
@@ -27,7 +27,7 @@ const isProviderGuide = scopeForPath(Astro.url.pathname) !== 'handbook';
 <div class:list={['page-title-row', { 'provider-guide-title-row': isProviderGuide }]}>
   <h1 id="_top">{title}</h1>
   {!draft && (
-    <ButtonGroup class="page-actions" aria-label="page actions">
+    <ButtonGroup class="page-actions" aria-label="page actions" data-pagefind-ignore>
       <Button
         class="page-copy-button"
         variant="outline"
@@ -69,11 +69,21 @@ const isProviderGuide = scopeForPath(Astro.url.pathname) !== 'handbook';
 
 <script>
   import { toast } from '@starwind-ui/astro/toast';
+  import { createMenu } from '@starwind-ui/runtime/menu';
 
   let cleanupPageActions = () => {};
   const setupPageActions = () => {
     cleanupPageActions();
     const controller = new AbortController();
+
+    // Page actions belong to their title row. Let Starwind close its own menu
+    // when the document moves, without interrupting scrolling within an overlay.
+    document.addEventListener('scroll', (event) => {
+      if (event.target !== document) return;
+      document.querySelectorAll<HTMLElement>('.page-actions [data-sw-menu][data-state="open"]').forEach((root) => {
+        createMenu(root).close();
+      });
+    }, { passive: true, signal: controller.signal });
 
     document.querySelectorAll<HTMLButtonElement>('[data-copy-page]').forEach((button) => {
       let markdownRequest: Promise<string> | undefined;

--- a/src/components/StarlightSidebar.astro
+++ b/src/components/StarlightSidebar.astro
@@ -9,8 +9,10 @@ import ShieldCheck from '@tabler/icons/outline/shield-check.svg';
 import { getHandbookPages, routeForEntry } from '../content';
 import { chapterForOrder, handbookScopes, scopeForPath } from '../site';
 import ProviderProductIcon from './ProviderProductIcon.astro';
+import { pageOutline } from '../navigation';
+import SidebarPrimitive from '@starwind-ui/astro/sidebar';
+import { sidebar, sidebarContainer, sidebarInner } from './starwind/sidebar/variants';
 import {
-  Sidebar,
   SidebarContent,
   SidebarMenu,
   SidebarMenuButton,
@@ -21,9 +23,6 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from './starwind/sidebar';
-
-type TocNode = { depth: number; slug: string; text: string; children: TocNode[] };
-type SidebarHeading = { depth: number; slug: string; text: string };
 
 const current = Astro.url.pathname;
 const activeScope = scopeForPath(current);
@@ -42,13 +41,7 @@ const chapterIcons = [Compass, ArrowRight, Adjustments, GitBranch, AppWindow, Sh
 
 const { toc } = Astro.locals.starlightRoute;
 const isOutline = Astro.locals.starlightRoute.entry.data.completion === 'outline';
-const flattenHeadings = (items: TocNode[]): SidebarHeading[] => items.flatMap((item) => [
-  { depth: item.depth, slug: item.slug, text: item.text },
-  ...flattenHeadings(item.children),
-]);
-const headings = toc && !isOutline
-  ? flattenHeadings(toc.items as TocNode[]).filter((item) => item.slug !== '_top' && item.depth <= 3)
-  : [];
+const headings = pageOutline(toc?.items, isOutline);
 ---
 
 <SidebarProvider
@@ -59,13 +52,22 @@ const headings = toc && !isOutline
   persistenceStorage="localStorage"
   mobileQuery="(max-width: 47.99rem)"
 >
-  <Sidebar
-    class="publication-sidebar"
+  {/* The header owns the mobile Sheet. Compose Starwind's desktop primitive
+      and stock variants here so the same content is not emitted in a second drawer. */}
+  <SidebarPrimitive.Sidebar
+    class={sidebar({ class: 'publication-sidebar' })}
+    data-state="expanded"
+    data-collapsible=""
+    data-collapsible-mode="icon"
+    data-variant="sidebar"
+    data-side="left"
+    data-slot="sidebar"
     collapsible="icon"
     side="left"
     variant="sidebar"
-    aria-label={activeScope === 'handbook' ? `${label} navigation` : `${label} handbook chapters`}
   >
+    <div class={sidebarContainer({ side: 'left', variant: 'sidebar' })} data-slot="sidebar-container" aria-label={activeScope === 'handbook' ? `${label} navigation` : `${label} handbook chapters`}>
+    <div class={sidebarInner({ variant: 'sidebar' })} data-sidebar="sidebar" data-slot="sidebar-inner">
     <div class="handbook-rail-head">
       <div class="guide-rail-identity">
         <ProviderProductIcon class="sidebar-provider-icon" light={providerIcon} dark={providerIconDark} size={28} />
@@ -109,5 +111,7 @@ const headings = toc && !isOutline
         })}
       </SidebarMenu>
     </SidebarContent>
-  </Sidebar>
+    </div>
+    </div>
+  </SidebarPrimitive.Sidebar>
 </SidebarProvider>

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,10 @@
+type TocNode = { depth: number; slug: string; text: string; children: TocNode[] };
+
+/** Both navigation surfaces use the same Starlight heading order and depth. */
+export function pageOutline(items: TocNode[] = [], isOutline = false) {
+  const flatten = (nodes: TocNode[]): Omit<TocNode, 'children'>[] => nodes.flatMap(({ children, ...heading }) => [
+    heading,
+    ...flatten(children),
+  ]);
+  return isOutline ? [] : flatten(items).filter(({ slug, depth }) => slug !== '_top' && depth <= 3);
+}

--- a/src/rehype/publication-elements.mjs
+++ b/src/rehype/publication-elements.mjs
@@ -68,7 +68,7 @@ function transformChildren(parent) {
             'code-copy', 'inline-flex', 'items-center', 'justify-center', 'gap-1.5', 'rounded-md',
             'font-medium', 'whitespace-nowrap', 'transition-all', 'outline-none', 'focus-visible:ring-3',
             'bg-foreground', 'text-background', 'hover:bg-foreground/90', 'focus-visible:ring-outline/50',
-            'h-9', 'px-4', 'text-sm',
+            'h-8', 'px-3', 'text-sm',
           ],
           'data-code-copy': '',
           'data-slot': 'button',

--- a/src/site.ts
+++ b/src/site.ts
@@ -7,6 +7,8 @@ export const site = {
   releaseHistory: 'https://github.com/anipotts/coding-agent-tips/releases',
   interfaceCopy: {
     menu: 'menu',
+    choosePage: 'choose page',
+    onThisPage: 'on this page',
     search: 'search',
     sources: 'sources',
     sharedFoundations: 'shared foundations',

--- a/src/styles/guide-navigation.css
+++ b/src/styles/guide-navigation.css
@@ -72,7 +72,7 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
   background: var(--soft);
   color: var(--ink);
 }
-.publication-sidebar [data-sw-sidebar-trigger] svg { inline-size: 1.125rem; block-size: 1.125rem; }
+.publication-sidebar [data-sw-sidebar-trigger] svg { inline-size: var(--control-icon-size); block-size: var(--control-icon-size); }
 
 .publication-sidebar-content {
   gap: 0;
@@ -105,7 +105,7 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 }
 .publication-sidebar [data-sidebar='menu-button'][data-active='true'] {
   background: var(--accent-soft);
-  color: var(--cobalt);
+  color: var(--accent-strong);
 }
 .publication-sidebar [data-sidebar='menu-button'] > svg { inline-size: 1rem; block-size: 1rem; }
 
@@ -130,7 +130,7 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 }
 .sidebar-page-outline [data-sidebar='menu-sub-button'][data-active='true'] {
   background: color-mix(in srgb, var(--accent-soft) 62%, transparent);
-  color: var(--cobalt);
+  color: var(--accent-strong);
 }
 
 .publication-sidebar[data-state='collapsed'] .guide-rail-identity,

--- a/src/styles/guide-navigation.css
+++ b/src/styles/guide-navigation.css
@@ -181,3 +181,33 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
   .right-sidebar { display: none !important; width: 0 !important; }
   .main-pane .sl-container { margin-inline: 3.25rem auto; }
 }
+.mobile-site-menu {
+  inline-size: min(22rem, calc(100dvw - 1rem));
+  max-inline-size: none;
+  padding: .75rem;
+  gap: .75rem;
+  color: var(--ink);
+  background: var(--surface-canvas);
+  border: 0;
+  border-inline-start: 1px solid var(--rule);
+}
+.mobile-menu-heading { padding: 0 2.5rem 0 .5rem; min-block-size: 2rem; justify-content: center; }
+.mobile-site-menu :where(button[data-slot], .mobile-menu-footer a) { block-size: var(--control-size); min-block-size: var(--control-size); }
+.mobile-menu-heading [data-slot='sheet-title'] { margin: 0; }
+.mobile-site-menu [data-slot='sheet-close'] { inset-block-start: .75rem; inset-inline-end: .75rem; inline-size: var(--control-size); border-radius: var(--radius-md); }
+.mobile-site-menu [data-slot='sheet-close'] svg { inline-size: 1rem; block-size: 1rem; }
+.mobile-page-picker-trigger { inline-size: 100%; justify-content: space-between; }
+.mobile-page-picker-trigger span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mobile-page-options { max-block-size: min(30rem, calc(100dvh - 8rem)); overflow-y: auto; inline-size: min(20.5rem, calc(100dvw - 2.5rem)); }
+.mobile-page-options [data-slot='dropdown-link-item'] { text-decoration: none; }
+.mobile-page-options [data-slot='dropdown-label'] { color: var(--slate); }
+.mobile-page-options [aria-current='page'] { background: var(--accent-soft); color: var(--accent-strong); }
+.mobile-page-navigation { flex: 1; min-block-size: 0; overflow-y: auto; overscroll-behavior: contain; }
+.mobile-page-outline { list-style: none; margin: 0; padding: 0; }
+.mobile-page-outline li { list-style: none; margin: 0; padding-inline-start: calc(var(--heading-depth) * .7rem); }
+.mobile-page-outline a { display: block; min-block-size: 1.65rem; padding: .2rem .5rem; border-radius: .3rem; color: var(--slate); text-decoration: none; }
+.mobile-page-outline a:hover { background: var(--soft); color: var(--ink); }
+.mobile-page-outline a[data-active='true'] { background: color-mix(in srgb, var(--accent-soft) 62%, transparent); color: var(--accent-strong); }
+.mobile-page-outline a:focus-visible { outline: 2px solid var(--accent-strong); outline-offset: -2px; }
+.mobile-menu-footer { padding-block-start: .5rem; border-block-start: 1px solid var(--rule); }
+.mobile-menu-footer a { text-decoration: none; }

--- a/src/styles/guide-navigation.css
+++ b/src/styles/guide-navigation.css
@@ -199,7 +199,7 @@ html:has(.publication-sidebar[data-state='collapsed']) { --left-rail-width: var(
 .mobile-page-picker-trigger { inline-size: 100%; justify-content: space-between; }
 .mobile-page-picker-trigger span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mobile-page-options { max-block-size: min(30rem, calc(100dvh - 8rem)); overflow-y: auto; inline-size: min(20.5rem, calc(100dvw - 2.5rem)); }
-.mobile-page-options [data-slot='dropdown-link-item'] { text-decoration: none; }
+.mobile-page-options [data-slot='dropdown-link-item'] { padding-inline-start: 1.2rem; text-decoration: none; }
 .mobile-page-options [data-slot='dropdown-label'] { color: var(--slate); }
 .mobile-page-options [aria-current='page'] { background: var(--accent-soft); color: var(--accent-strong); }
 .mobile-page-navigation { flex: 1; min-block-size: 0; overflow-y: auto; overscroll-behavior: contain; }

--- a/src/styles/publication.css
+++ b/src/styles/publication.css
@@ -7,10 +7,8 @@ header.header { z-index: var(--z-navigation); height: var(--site-header-height);
 }
 .sidebar-content { height: 100%; min-height: 0 !important; padding: 0 !important; }
 .sidebar-content::after { display: none !important; }
-.handbook-rail-head { position: relative; min-height: 2.75rem; display: flex; align-items: center; justify-content: space-between; gap: .75rem; }
 .sidebar-label > span:first-child { color: var(--ink); }
 .sidebar-label > span:first-child { display: flex; align-items: center; gap: .45rem; }
-.sidebar-provider-icon { inline-size: 1.1rem; block-size: 1.1rem; border-radius: .22rem; background: var(--surface-raised); }
 .sidebar-kind { color: var(--slate); }
 .content-panel { border-top: 0 !important; }
 .main-frame { transition: padding-inline-start var(--motion-ui-duration) var(--motion-ui-ease); }

--- a/src/styles/publication.css
+++ b/src/styles/publication.css
@@ -63,12 +63,11 @@ header.header { z-index: var(--z-navigation); height: var(--site-header-height);
 }
 
 .surface-bento { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: 1rem; margin: 1.75rem 0 2.5rem; }
-.surface-bento figure { min-width: 0; margin: 0; border: 1px solid var(--rule); border-radius: var(--radius-ui); overflow: hidden; background: var(--soft); }
+.surface-bento figure { min-width: 0; margin: 0; border: 0; background: transparent; }
 .surface-bento figure { position: relative; }
 .surface-bento a { display: block; text-decoration: none; }
-.surface-bento img { display: block; inline-size: 100%; aspect-ratio: 16 / 9; object-fit: cover; background: var(--soft); }
+.surface-bento img { display: block; inline-size: 100%; block-size: auto; background: transparent; }
 .surface-bento.intro-visual { grid-template-columns: minmax(0, 1fr); margin-top: 1rem; }
-.surface-bento.intro-visual img { aspect-ratio: 3600 / 2260; }
 .surface-bento figure[data-image-dialog-ready] figcaption { display: none; }
 .publication-image-trigger { display: block; inline-size: 100%; padding: 0; border: 0; background: transparent; cursor: zoom-in; }
 .publication-image-dialog { inline-size: min(70rem, calc(100vw - 2rem)); max-inline-size: calc(100vw - 2rem); max-block-size: calc(100dvh - 2rem); padding: 0; overflow: auto; }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -267,13 +267,6 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
   .main-pane .sl-container { max-width: 52rem; margin-inline: auto; }
   button[aria-label='Menu'] { display: none !important; }
   .mobile-site-menu-trigger { display: inline-flex !important; }
-  .mobile-site-menu nav { display: grid; padding: .5rem 1rem 1rem; }
-  .mobile-site-menu nav a { padding: .75rem; border-radius: var(--radius-ui); color: var(--ink); text-decoration: none; }
-  .mobile-site-menu nav a + a { border-top: 1px solid var(--rule); }
-  .mobile-site-menu nav a:hover, .mobile-site-menu nav a[aria-current='page'] { background: var(--accent-soft); color: var(--cobalt); }
-  .mobile-site-menu footer { margin-top: .45rem; padding-top: .45rem; border-top: 1px solid var(--rule); }
-  .mobile-site-menu footer a { display: flex; align-items: center; gap: .55rem; }
-  .mobile-site-menu footer svg { inline-size: 1rem; block-size: 1rem; }
   .header-search site-search dialog {
     inset: .625rem var(--site-gutter) auto auto;
     inline-size: calc(100dvw - 2 * var(--site-gutter));
@@ -309,10 +302,10 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
 
 @media (max-width: 59.99rem) {
   .header-search { inline-size: var(--control-size); }
-  .site-header:has(dialog[open]) { grid-template-columns: 1.5rem minmax(0, 1fr); column-gap: .75rem; padding-inline: var(--site-gutter); }
-  .site-header:has(dialog[open]) .site-name { margin: 0; }
-  .site-header:has(dialog[open]) .site-name span { display: none; }
-  .site-header:has(dialog[open]) .header-actions { justify-self: stretch; margin: 0; padding: 0; border: 0; background: transparent; }
+  .site-header:has(.header-search dialog[open]) { grid-template-columns: 1.5rem minmax(0, 1fr); column-gap: .75rem; padding-inline: var(--site-gutter); }
+  .site-header:has(.header-search dialog[open]) .site-name { margin: 0; }
+  .site-header:has(.header-search dialog[open]) .site-name span { display: none; }
+  .site-header:has(.header-search dialog[open]) .header-actions { justify-self: stretch; margin: 0; padding: 0; border: 0; background: transparent; }
   .header-search:has(dialog[open]) { flex: 1; min-inline-size: 0; inline-size: auto; }
   .header-search site-search dialog { inset: .625rem auto auto calc(var(--site-gutter) + 2.25rem); inline-size: calc(100dvw - 2 * var(--site-gutter) - 6.75rem); margin: 0; translate: 0; }
   @supports (width: anchor-size(width)) {

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -133,11 +133,10 @@ body[data-search-modal-open] { overflow: auto; }
 
 /* Reserve real header space for the input; the native search dialog keeps keyboard
    and dismissal behavior while only the result list extends below the row. */
-.header-search { --search-expanded-width: clamp(12rem, 24vw, 24rem); inline-size: 7rem; transition: inline-size var(--motion-ui-duration) var(--motion-ui-ease); }
+.header-search { --search-expanded-width: clamp(10rem, 18vw, 16rem); inline-size: var(--search-expanded-width); }
+.header-search site-search > button { inline-size: 100%; }
 .header-search:has(dialog[open]) { inline-size: var(--search-expanded-width); }
 .header-search:has(dialog[open]) site-search > button { inline-size: 100%; max-inline-size: none; opacity: 0; pointer-events: none; }
-.site-header:has(dialog[open]) { grid-template-columns: auto auto minmax(0, 1fr); column-gap: 1rem; }
-.site-header:has(dialog[open]) .site-name span { display: none; }
 [data-slot='dropdown-content'] [role='menuitem'] { min-block-size: var(--control-size); padding: .5rem; gap: .5rem; color: inherit; text-decoration: none; }
 [data-slot='dropdown-content'] [role='menuitem'] svg { inline-size: var(--control-icon-size); block-size: var(--control-icon-size); }
 .outline-review-state { max-width: 42rem; padding: 1rem 1.1rem; border: 1px solid var(--rule); border-radius: var(--radius-md); background: var(--surface-subtle); }
@@ -229,17 +228,16 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
 
 @media (max-width: 47.99rem) {
   :root { --site-header-height: 5.75rem; --sl-mobile-toc-height: 0rem; }
-  .site-header { padding-inline: 0; grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: 3.25rem 2.5rem; }
-  .site-name { grid-column: 1; grid-row: 1; margin-inline-start: var(--site-gutter); }
+  .site-header { padding-inline: var(--site-gutter); grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: 3.25rem 2.5rem; }
+  .site-name { grid-column: 1; grid-row: 1; margin-inline-start: 0; }
   .header-actions {
     grid-column: 2;
     grid-row: 1;
-    gap: .125rem;
-    margin-inline-end: var(--site-gutter);
-    padding: .125rem;
-    border: 1px solid var(--rule);
-    border-radius: var(--radius-md);
-    background: color-mix(in srgb, var(--surface-subtle) 58%, transparent);
+    gap: .25rem;
+    margin-inline-end: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
   }
   .header-search site-search > button,
   .site-header-control {
@@ -249,7 +247,7 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
     min-block-size: 2rem;
     padding: 0;
     border: 0;
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius-md);
     background: transparent;
   }
   .header-search site-search > button { justify-content: center; }
@@ -260,7 +258,7 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
   .header-search site-search > button span,
   .header-search site-search > button kbd { display: none; }
   .header-actions .github-link { display: none; }
-  .provider-tabs { grid-column: 1 / -1; grid-row: 2; justify-content: center; gap: .125rem; padding: .125rem var(--site-gutter) .375rem; }
+  .provider-tabs { grid-column: 1 / -1; grid-row: 2; justify-content: center; gap: .125rem; padding: .125rem 0 .375rem; }
   .provider-tabs a { min-height: 1.875rem; padding: .25rem .5rem; }
   .sidebar-pane { display: none !important; }
   .right-sidebar-container { display: block !important; flex: 0 0 0 !important; width: 0 !important; }
@@ -313,6 +311,7 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
   .header-search { inline-size: var(--control-size); }
   .site-header:has(dialog[open]) { grid-template-columns: 1.5rem minmax(0, 1fr); column-gap: .75rem; padding-inline: var(--site-gutter); }
   .site-header:has(dialog[open]) .site-name { margin: 0; }
+  .site-header:has(dialog[open]) .site-name span { display: none; }
   .site-header:has(dialog[open]) .header-actions { justify-self: stretch; margin: 0; padding: 0; border: 0; background: transparent; }
   .header-search:has(dialog[open]) { flex: 1; min-inline-size: 0; inline-size: auto; }
   .header-search site-search dialog { inset: .625rem auto auto calc(var(--site-gutter) + 2.25rem); inline-size: calc(100dvw - 2 * var(--site-gutter) - 6.75rem); margin: 0; translate: 0; }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -30,9 +30,10 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
 .header-actions { grid-column: 3; grid-row: 1; display: flex; align-items: center; justify-self: end; gap: .45rem; }
 .github-link { display: inline-flex; align-items: center; gap: .4rem; justify-self: end; color: var(--ink); }
 .github-link { text-decoration: none; }
-.github-link svg,
+.header-search site-search > button svg,
+.site-header-control svg,
 .site-header-control [data-theme-icon-wrapper],
-.site-header-control [data-theme-icon] { inline-size: 1.125rem; block-size: 1.125rem; }
+.site-header-control [data-theme-icon] { inline-size: var(--control-icon-size); block-size: var(--control-icon-size); }
 .header-search site-search > button,
 .site-header-control { min-block-size: 2rem; border-radius: var(--radius-md); }
 .site-header-control {
@@ -60,23 +61,23 @@ a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px soli
   position: fixed;
   inset: .75rem calc(var(--site-gutter) + 4.9rem) auto auto;
   z-index: var(--z-preview);
-  inline-size: min(26rem, calc(100dvw - 2rem));
+  inline-size: var(--search-expanded-width, 20rem);
   max-inline-size: none;
   block-size: max-content;
   min-block-size: 0;
   max-block-size: min(28rem, calc(100dvh - var(--site-header-height) - 1rem));
   margin: 0;
-  border-color: var(--rule);
-  overflow: clip;
+  border: 0;
+  overflow: visible;
   border-radius: var(--radius-md);
-  background: var(--surface-raised);
+  background: transparent;
   color: var(--ink);
-  box-shadow: 0 .75rem 2rem rgba(0, 0, 0, .14);
+  box-shadow: none;
   transform-origin: top right;
   animation: search-surface-open 140ms var(--ease-out);
 }
 .header-search site-search dialog::backdrop { background: transparent; backdrop-filter: none; }
-.header-search site-search .dialog-frame { flex: none; inline-size: 100%; min-inline-size: 0; max-block-size: inherit; gap: .5rem; padding: .375rem; overscroll-behavior: contain; scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--slate) 52%, transparent) transparent; }
+.header-search site-search .dialog-frame { flex: none; inline-size: 100%; min-inline-size: 0; max-block-size: inherit; gap: 0; padding: 0; overflow: visible; }
 .header-search site-search .search-container,
 .header-search #starlight__search,
 .header-search #starlight__search .pagefind-ui { inline-size: 100%; min-inline-size: 0; }
@@ -106,19 +107,39 @@ body[data-search-modal-open] { overflow: auto; }
   --pagefind-ui-font: 'Instrument Sans', system-ui, sans-serif;
 }
 .header-search #starlight__search .pagefind-ui__search-input {
-  block-size: 2.5rem !important;
-  min-block-size: 2.5rem;
-  padding-inline-start: 2.75rem !important;
-  padding-inline-end: 3rem !important;
+  block-size: var(--control-size) !important;
+  min-block-size: var(--control-size);
+  inline-size: 100%;
+  padding-block: 0;
+  padding-inline-start: 2rem !important;
+  padding-inline-end: 2rem !important;
+  border: 1px solid var(--rule);
   border-radius: var(--radius-md);
-  background: var(--surface-subtle) !important;
+  background: var(--surface-raised) !important;
   color: var(--ink) !important;
 }
-.header-search #starlight__search .pagefind-ui__search-input:focus { border-color: var(--cobalt); box-shadow: 0 0 0 3px var(--accent-soft); }
+.header-search #starlight__search .pagefind-ui__search-input:focus { border-color: var(--slate); outline: none; box-shadow: none; }
+.header-search #starlight__search .pagefind-ui__search-input::placeholder { opacity: 1; color: var(--slate); }
+.header-search #starlight__search .pagefind-ui__form::before { top: .5rem; left: .5rem; width: var(--control-icon-size); height: var(--control-icon-size); background-color: var(--slate); }
+.header-search #starlight__search .pagefind-ui__search-clear { top: 0; right: 0; inset-inline-end: 0; width: var(--control-size); height: var(--control-size); border: 0; }
+.header-search site-search button[data-close-modal] { display: none; }
+.header-search #starlight__search .pagefind-ui__drawer { margin-top: .5rem; padding: .5rem; max-height: min(26rem, calc(100dvh - var(--site-header-height) - 1rem)); overflow: auto; border: 1px solid var(--rule); border-radius: var(--radius-md); background: var(--surface-raised); box-shadow: 0 .35rem 1rem rgb(0 0 0 / .12); }
+.header-search #starlight__search .pagefind-ui__results-area { margin-top: 0; }
+.header-search #starlight__search :where(.pagefind-ui__result-inner, .pagefind-ui__result-nested, .pagefind-ui__result-title, .pagefind-ui__result-excerpt) { min-inline-size: 0; overflow-wrap: anywhere; }
 .header-search #starlight__search .pagefind-ui__result { padding-block: 1rem; border-top-color: var(--rule); }
 .header-search #starlight__search .pagefind-ui__result-link { color: var(--ink); text-decoration: none; }
 .header-search #starlight__search .pagefind-ui__result-link:hover { color: var(--cobalt); }
 .header-search #starlight__search mark { border-radius: .18rem; background: var(--accent-soft); color: var(--accent-strong); }
+
+/* Reserve real header space for the input; the native search dialog keeps keyboard
+   and dismissal behavior while only the result list extends below the row. */
+.header-search { --search-expanded-width: clamp(12rem, 24vw, 24rem); inline-size: 7rem; transition: inline-size var(--motion-ui-duration) var(--motion-ui-ease); }
+.header-search:has(dialog[open]) { inline-size: var(--search-expanded-width); }
+.header-search:has(dialog[open]) site-search > button { inline-size: 100%; max-inline-size: none; opacity: 0; pointer-events: none; }
+.site-header:has(dialog[open]) { grid-template-columns: auto auto minmax(0, 1fr); column-gap: 1rem; }
+.site-header:has(dialog[open]) .site-name span { display: none; }
+[data-slot='dropdown-content'] [role='menuitem'] { min-block-size: var(--control-size); padding: .5rem; gap: .5rem; color: inherit; text-decoration: none; }
+[data-slot='dropdown-content'] [role='menuitem'] svg { inline-size: var(--control-icon-size); block-size: var(--control-icon-size); }
 .outline-review-state { max-width: 42rem; padding: 1rem 1.1rem; border: 1px solid var(--rule); border-radius: var(--radius-md); background: var(--surface-subtle); }
 .outline-review-state p { margin: 0; }
 .outline-review-state p + p { margin-top: .45rem; color: var(--slate); }
@@ -172,7 +193,7 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
 .site-footer p { margin: 0; }
 .footer-meta { justify-self: center; }
 .site-footer nav { display: flex; align-items: center; justify-self: end; gap: 1.5rem; }
-.footer-github svg { inline-size: 1.15rem; block-size: 1.15rem; }
+.footer-github svg { inline-size: var(--control-icon-size); block-size: var(--control-icon-size); }
 
 /* Starlight publication shell */
 @media (min-width: 72rem) {
@@ -264,18 +285,6 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
     margin: 0;
     translate: 0;
   }
-  .header-search site-search .dialog-frame {
-    min-block-size: 0;
-    padding: .375rem;
-  }
-  .header-search site-search button[data-close-modal] {
-    inset: .375rem .375rem auto auto;
-    min-block-size: 2.5rem;
-    padding-inline: .5rem;
-    border-radius: var(--radius-md);
-    color: var(--cobalt);
-  }
-  .header-search #starlight__search { --sl-search-cancel-space: 4.5rem; }
 }
 
 @media (max-width: 47.99rem) {
@@ -298,6 +307,20 @@ html[data-theme='dark'] .provider-product-icon.has-theme-pair .provider-product-
 
 @media (max-width: 22rem) {
   .site-name span { display: none; }
+}
+
+@media (max-width: 59.99rem) {
+  .header-search { inline-size: var(--control-size); }
+  .site-header:has(dialog[open]) { grid-template-columns: 1.5rem minmax(0, 1fr); column-gap: .75rem; padding-inline: var(--site-gutter); }
+  .site-header:has(dialog[open]) .site-name { margin: 0; }
+  .site-header:has(dialog[open]) .header-actions { justify-self: stretch; margin: 0; padding: 0; border: 0; background: transparent; }
+  .header-search:has(dialog[open]) { flex: 1; min-inline-size: 0; inline-size: auto; }
+  .header-search site-search dialog { inset: .625rem auto auto calc(var(--site-gutter) + 2.25rem); inline-size: calc(100dvw - 2 * var(--site-gutter) - 6.75rem); margin: 0; translate: 0; }
+  @supports (width: anchor-size(width)) {
+    .header-search site-search dialog { position-anchor: --site-search-trigger; inset: auto; top: anchor(top); left: anchor(left); inline-size: anchor-size(width); }
+  }
+  .header-search site-search .dialog-frame { padding: 0; }
+  .header-search site-search button[data-close-modal] { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/starwind.css
+++ b/src/styles/starwind.css
@@ -3,7 +3,7 @@
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 @import "tw-animate-css";
-@plugin "@tailwindcss/forms";
+@plugin "@tailwindcss/forms" { strategy: 'class'; }
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -33,6 +33,8 @@
   --radius-md: .5rem;
   --radius-pill: 999px;
   --radius-ui: var(--radius-sm);
+  --control-size: 2rem;
+  --control-icon-size: 1rem;
   --motion-ui-duration: 160ms;
   --motion-ui-ease: cubic-bezier(.2, .75, .25, 1);
   --z-navigation: 50;

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -194,6 +194,13 @@ body {
 
 .mobile-site-menu nav a[aria-current='page'] { font-weight: 600; }
 
+.mobile-site-menu,
+.mobile-menu-heading [data-slot='sheet-title'],
+.mobile-page-options [data-slot='dropdown-link-item'],
+.mobile-page-options [data-slot='dropdown-label'],
+.mobile-menu-footer a { font-size: var(--type-navigation-size); line-height: var(--type-navigation-line); }
+.mobile-menu-heading [data-slot='sheet-title'] { font-weight: 600; }
+
 .publication-sidebar [data-sidebar='menu-button'] {
   font-size: var(--type-navigation-size);
   line-height: var(--type-navigation-line);

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -10,11 +10,11 @@
   --type-subheading-size: 1.375rem;
   --type-body-size: 1.125rem;
   --type-dense-size: 1rem;
-  --type-navigation-size: .875rem;
+  --type-navigation-size: .75rem;
   --type-metadata-size: .75rem;
   --type-body-line: 1.875rem;
   --type-dense-line: 1.5rem;
-  --type-navigation-line: 1.25rem;
+  --type-navigation-line: 1rem;
   --type-metadata-line: 1.125rem;
   --sl-font: var(--font-sans);
   --sl-font-mono: var(--font-mono);
@@ -185,23 +185,23 @@ body {
 
 .mobile-site-menu nav a {
   font-family: var(--font-sans);
-  font-size: 1rem;
+  font-size: var(--type-navigation-size);
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 1.5rem;
+  line-height: var(--type-navigation-line);
   text-transform: none;
 }
 
 .mobile-site-menu nav a[aria-current='page'] { font-weight: 600; }
 
 .publication-sidebar [data-sidebar='menu-button'] {
-  font-size: .875rem;
-  line-height: 1.25rem;
+  font-size: var(--type-navigation-size);
+  line-height: var(--type-navigation-line);
 }
 
 .sidebar-page-outline [data-sidebar='menu-sub-button'] {
-  font-size: .78rem;
-  line-height: 1.2rem;
+  font-size: var(--type-navigation-size);
+  line-height: var(--type-navigation-line);
 }
 
 .section-label, .footer-meta,
@@ -240,11 +240,17 @@ body {
   line-height: 1rem;
 }
 
-.page-actions :where(button, a) {
+.page-actions :where(button, a),
+[data-slot='dropdown-content'], [data-slot='dropdown-content'] [role='menuitem'],
+[data-slot='tooltip-content'], [data-slot='toast'],
+[data-slot='toast-title'], [data-slot='toast-description'], [data-slot='toast-action'],
+.header-search site-search > button,
+.header-search #starlight__search :where(input, button, p, a),
+.source-summary-title, .page-sources li {
   font-family: var(--font-sans);
-  font-size: .75rem;
+  font-size: var(--type-navigation-size);
   font-weight: 400;
-  line-height: 1rem;
+  line-height: var(--type-navigation-line);
 }
 
 .registered-link-card-heading strong {
@@ -292,7 +298,7 @@ body {
 :where(.home-content, .sl-markdown-content, .run-page) pre code,
 :where(.home-content, .sl-markdown-content, .run-page) pre code span {
   font-family: var(--font-mono);
-  font-size: var(--type-navigation-size);
+  font-size: .875rem;
   font-weight: 400;
   line-height: 1.375rem;
 }
@@ -316,7 +322,7 @@ body {
 .guide-rail-identity .sidebar-label > span:first-child,
 .guide-rail-identity .sidebar-kind {
   font-family: var(--font-sans);
-  font-size: .8125rem;
+  font-size: var(--type-navigation-size);
   font-weight: 400;
   letter-spacing: 0;
   line-height: 1.125rem;
@@ -326,7 +332,7 @@ body {
 .publication-sidebar [data-sidebar='menu-button'],
 .publication-sidebar [data-sidebar='menu-sub-button'] {
   font-family: var(--font-sans);
-  font-size: .8125rem;
+  font-size: var(--type-navigation-size);
   font-weight: 400;
   line-height: 1.125rem;
 }


### PR DESCRIPTION
Unify handbook navigation and compact controls across desktop and mobile. The mobile sheet now offers a page picker grouped by guide, indented page choices, and the same section outline as desktop. Search stays within the header row, utility menus use consistent typography, and publication images retain their natural presentation.

Validation covers navigation, search, menu dismissal, keyboard focus, responsive layouts, performance budgets, and accessibility in both themes. Full `bun run verify` passed on `ec7efa225aaaa9a21005eb77b01b884ce359808b`, including accessibility across 15 routes, eight widths, and both themes. Required CI must also pass before merge.

The change contains UI code, design guidance, and regression checks. Editorial drafts remain in their separate worktree.
